### PR TITLE
:bookmark: Update renovate.json :pushpin:

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,6 @@
       "schedule": "every 1st day of the month"
     }
   ],
-  "extends": ["config:base", ":assignee(arg0)", ":reviewer(arg0)"]
+  "extends": ["config:base", ":assignee(arg0)", ":reviewer(arg0)"],
+	"nodeVersion": ">=18"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchPackageNames": ["npm"],
+      "matchPackageNames": ["npm", "astro", "node"],
 			"matchUpdateTypes": ["patch", "minor"],
 			"automerge": true,
       "schedule": ["after 5pm on Friday"]

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,9 @@
   "packageRules": [
     {
       "matchPackageNames": ["npm"],
-      "schedule": "every 1st day of the month"
+			"matchUpdateTypes": ["patch", "minor"],
+			"automerge": true,
+      "schedule": ["after 5pm on Friday"]
     }
   ],
   "extends": ["config:base", ":assignee(arg0)", ":reviewer(arg0)"],


### PR DESCRIPTION
Especificar la versión mínima de Node.js: Puede especificar una versión mínima de Node.js que debe estar instalada en el sistema para que Renovate pueda ejecutarse. Esto es útil si necesita garantizar que las actualizaciones de paquetes se ejecuten en un entorno compatible.