### PR TITLE
fix(dependencies) Fix Renovate Configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,5 @@
       "schedule": ["after 5pm on Friday"]
     }
   ],
-  "extends": ["config:base", ":assignee(arg0)", ":reviewer(arg0)"],
-	"nodeVersion": ">=18"
+  "extends": ["config:base", ":assignee(arg0)", ":reviewer(arg0)"]
 }


### PR DESCRIPTION
There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.

Location: renovate.json
Error type: The renovate configuration file contains some invalid settings
Message: Invalid configuration option: nodeVersion

Close #368