### PR TITLE
chore(deps): Update SonarCloud GitHub action version

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,7 +24,7 @@ jobs:
 
         # You can pin the exact commit or the version.
         # uses: SonarSource/sonarcloud-github-action@de2e56b42aa84d0b1c5b622644ac17e505c9a049
-        uses: SonarSource/sonarcloud-github-action@4b4d7634dab97dcee0b75763a54a6dc92a9e6bc1
+        uses: SonarSource/sonarcloud-github-action@a244ec8e13e936b0bf97ee18f0ab980ffc2f2310
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -15,7 +15,7 @@ import critters from 'astro-critters'
 import { manifest, workbox } from './src/plugins/pwa'
 import { config } from './src/plugins/netlify-cms'
 
-const DEV_PORT = 3000
+const DEV_PORT: number = 3000
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
Updating the version of SonarCloud GitHub action used in CI/CD workflow from 4b4d7634dab97dcee0b75763a54a6dc92a9e6bc1 to a244ec8e13e936b0bf97ee18f0ab980ffc2f2310. This is to ensure that we are using the latest version of the SonarCloud GitHub action which contains the most recent bug fixes and performance improvements.