### PR TITLE
Feature/netlify cms

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -5,3 +5,4 @@ https://you.com/*
 https://www.looka.com/*
 https://pkgs.org/download/proxychains-ng
 https://packages.ubuntu.com/*
+https://formspree.io/*

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -6,7 +6,7 @@ import robotsTxt from 'astro-robots-txt';
 import NetlifyCMS from 'astro-netlify-cms';
 import remarkToc from 'remark-toc';
 import icon from 'astro-icon';
-import { config } from './src/plugins/netlify-cms';
+import cmsConfig from './src/plugins/netlify-cms';
 import vue from '@astrojs/vue';
 
 const DEV_PORT: number = 3000;
@@ -35,7 +35,7 @@ export default defineConfig({
 		tailwind(),
 		robotsTxt(),
 		NetlifyCMS({
-			config,
+			config: cmsConfig
 		}),
 		icon({
 			iconDir: 'src/icons',

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
 		tailwind(),
 		robotsTxt(),
 		NetlifyCMS({
-			config: cmsConfig
+			config: cmsConfig,
 		}),
 		icon({
 			iconDir: 'src/icons',

--- a/src/components/molecules/Search/SearchBox.vue
+++ b/src/components/molecules/Search/SearchBox.vue
@@ -150,3 +150,9 @@ const getModalTranslations = (value: ModalTranslations, key: string): string => 
 </template>
 
 <style scoped></style>
+
+<script lang="ts">
+export default {
+	name: 'SearchBox'
+}
+</script>

--- a/src/components/molecules/Search/SearchBox.vue
+++ b/src/components/molecules/Search/SearchBox.vue
@@ -148,4 +148,3 @@ const getModalTranslations = (value: ModalTranslations, key: string): string => 
 		</template>
 	</Modal>
 </template>
-

--- a/src/components/molecules/Search/SearchBox.vue
+++ b/src/components/molecules/Search/SearchBox.vue
@@ -149,10 +149,3 @@ const getModalTranslations = (value: ModalTranslations, key: string): string => 
 	</Modal>
 </template>
 
-<style scoped></style>
-
-<script lang="ts">
-export default {
-	name: 'SearchBox',
-};
-</script>

--- a/src/components/molecules/Search/SearchBox.vue
+++ b/src/components/molecules/Search/SearchBox.vue
@@ -153,6 +153,6 @@ const getModalTranslations = (value: ModalTranslations, key: string): string => 
 
 <script lang="ts">
 export default {
-	name: 'SearchBox'
-}
+	name: 'SearchBox',
+};
 </script>

--- a/src/components/molecules/Search/index.astro
+++ b/src/components/molecules/Search/index.astro
@@ -4,8 +4,7 @@ import { getCollection } from 'astro:content';
 import { jsonToArticle, type Article } from '@models:Article';
 import { getLangFromUrl } from '@i18n:index';
 import type { DocSearchTranslation } from '@i18n:search-translation';
-// @ts-expect-error
-import Search from './Search.vue';
+import SearchBox from './SearchBox.vue';
 
 const { pathname } = Astro.url;
 const isBlogRoot =
@@ -28,7 +27,7 @@ const docSearchStrings: DocSearchTranslation = getDocSearchStrings(Astro);
 
 {
 	isBlogRoot && (
-		<Search
+		<SearchBox
 			client:only="vue"
 			id="search-articles"
 			articles={sortedPublishedBlogEntries}

--- a/src/components/molecules/Search/index.astro
+++ b/src/components/molecules/Search/index.astro
@@ -4,6 +4,7 @@ import { getCollection } from 'astro:content';
 import { jsonToArticle, type Article } from '@models:Article';
 import { getLangFromUrl } from '@i18n:index';
 import type { DocSearchTranslation } from '@i18n:search-translation';
+// @ts-expect-error
 import SearchBox from './SearchBox.vue';
 
 const { pathname } = Astro.url;

--- a/src/content/technologies/java.json
+++ b/src/content/technologies/java.json
@@ -2,5 +2,5 @@
   "id": "java",
   "name": "Java",
   "icon": "cib:java",
-  "url": "https://www.java.com/"
+  "url": "https://www.java.com/en/"
 }

--- a/src/plugins/netlify-cms-en.ts
+++ b/src/plugins/netlify-cms-en.ts
@@ -2,12 +2,13 @@ import type { CmsCollection } from 'netlify-cms-core';
 export const collections: CmsCollection[] = [
 	// Content collections
 	{
-		name: 'posts',
-		label: 'Posts',
+		name: 'posts-en',
+		label: 'Posts (English)',
 		folder: 'src/content/blog',
 		create: true,
 		slug: '{{slug}}',
 		label_singular: 'Post',
+		filter: {field: "lang", value: "en"},
 		fields: [
 			{ label: 'Title', name: 'title', widget: 'string' },
 			{ label: 'Description', name: 'description', widget: 'string' },
@@ -20,6 +21,7 @@ export const collections: CmsCollection[] = [
 				widget: 'select',
 				options: ['en', 'es'],
 				default: 'en',
+				required: true,
 			},
 			{ label: 'Cover', name: 'cover', widget: 'image', required: false },
 			{ label: 'Author', name: 'author', widget: 'string' },
@@ -63,12 +65,13 @@ export const collections: CmsCollection[] = [
 		],
 	},
 	{
-		name: 'jobs',
-		label: 'Jobs',
+		name: 'jobs-en',
+		label: 'Jobs (English)',
 		folder: 'src/content/jobs',
 		slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
 		create: true,
 		extension: 'json',
+		filter: {field: "lang", value: "en"},
 		fields: [
 			{ label: 'Title', name: 'title', widget: 'string' },
 			{
@@ -96,12 +99,13 @@ export const collections: CmsCollection[] = [
 		],
 	},
 	{
-		name: 'projects',
-		label: 'Projects',
+		name: 'projects-en',
+		label: 'Projects (English)',
 		folder: 'src/content/projects',
 		slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
 		create: true,
 		extension: 'json',
+		filter: {field: "lang", value: "en"},
 		fields: [
 			{ label: 'Title', name: 'title', widget: 'string' },
 			{

--- a/src/plugins/netlify-cms-en.ts
+++ b/src/plugins/netlify-cms-en.ts
@@ -8,7 +8,7 @@ export const collections: CmsCollection[] = [
 		create: true,
 		slug: '{{slug}}',
 		label_singular: 'Post',
-		filter: {field: "lang", value: "en"},
+		filter: { field: 'lang', value: 'en' },
 		fields: [
 			{ label: 'Title', name: 'title', widget: 'string' },
 			{ label: 'Description', name: 'description', widget: 'string' },
@@ -71,7 +71,7 @@ export const collections: CmsCollection[] = [
 		slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
 		create: true,
 		extension: 'json',
-		filter: {field: "lang", value: "en"},
+		filter: { field: 'lang', value: 'en' },
 		fields: [
 			{ label: 'Title', name: 'title', widget: 'string' },
 			{
@@ -105,7 +105,7 @@ export const collections: CmsCollection[] = [
 		slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
 		create: true,
 		extension: 'json',
-		filter: {field: "lang", value: "en"},
+		filter: { field: 'lang', value: 'en' },
 		fields: [
 			{ label: 'Title', name: 'title', widget: 'string' },
 			{

--- a/src/plugins/netlify-cms-es.ts
+++ b/src/plugins/netlify-cms-es.ts
@@ -8,7 +8,7 @@ export const collections: CmsCollection[] = [
 		create: true,
 		slug: '{{slug}}',
 		label_singular: 'Post',
-		filter: {field: "lang", value: "es"},
+		filter: { field: 'lang', value: 'es' },
 		fields: [
 			{ label: 'Título', name: 'title', widget: 'string' },
 			{ label: 'Descripción', name: 'description', widget: 'string' },

--- a/src/plugins/netlify-cms-es.ts
+++ b/src/plugins/netlify-cms-es.ts
@@ -2,12 +2,13 @@ import type { CmsCollection } from 'netlify-cms-core';
 export const collections: CmsCollection[] = [
 	// Content collections
 	{
-		name: 'posts_es',
-		label: 'Artículos',
-		folder: 'src/content/blog/es',
+		name: 'posts-es',
+		label: 'Posts (Español)',
+		folder: 'src/content/blog',
 		create: true,
 		slug: '{{slug}}',
-		label_singular: 'Artículo',
+		label_singular: 'Post',
+		filter: {field: "lang", value: "es"},
 		fields: [
 			{ label: 'Título', name: 'title', widget: 'string' },
 			{ label: 'Descripción', name: 'description', widget: 'string' },
@@ -20,6 +21,7 @@ export const collections: CmsCollection[] = [
 				widget: 'select',
 				options: ['en', 'es'],
 				default: 'es',
+				required: true,
 			},
 			{ label: 'Cover', name: 'cover', widget: 'image', required: false },
 			{ label: 'Autor', name: 'author', widget: 'string' },

--- a/src/plugins/netlify-cms.ts
+++ b/src/plugins/netlify-cms.ts
@@ -1,22 +1,22 @@
 import type { CmsConfig } from 'netlify-cms-core';
-import cmsConfigCommon from './netlify-cms-common';
-import cmsConfigEn from './netlify-cms-en';
-import cmsConfigEs from './netlify-cms-es';
-export const config: Omit<CmsConfig, 'load_config_file' | 'local_backend'> = {
+import { collections as enCollections } from './netlify-cms-en';
+import { collections as esCollections } from './netlify-cms-es';
+import { collections as commonCollections } from './netlify-cms-common';
+
+const config: CmsConfig = {
 	backend: {
 		name: 'git-gateway',
-		branch: 'master',
+		branch: 'main',
 	},
+	local_backend: true,
 	publish_mode: 'editorial_workflow',
-	media_folder: 'public/uploads',
-	public_folder: 'public/uploads',
-	site_url: 'https://yunielacosta.com',
-	display_url: 'https://yunielacosta.com',
-	logo_url: 'https://yunielacosta.com/logo.svg',
+	media_folder: 'public/images',
+	public_folder: '/images',
 	collections: [
-		// Content collections
-		...cmsConfigCommon,
-		...cmsConfigEn,
-		...cmsConfigEs,
+		...commonCollections,
+		...enCollections,
+		...esCollections,
 	],
 };
+
+export default config;

--- a/src/plugins/netlify-cms.ts
+++ b/src/plugins/netlify-cms.ts
@@ -12,11 +12,7 @@ const config: CmsConfig = {
 	publish_mode: 'editorial_workflow',
 	media_folder: 'public/images',
 	public_folder: '/images',
-	collections: [
-		...commonCollections,
-		...enCollections,
-		...esCollections,
-	],
+	collections: [...commonCollections, ...enCollections, ...esCollections],
 };
 
 export default config;

--- a/tests/integration/blog-search.spec.ts
+++ b/tests/integration/blog-search.spec.ts
@@ -1,21 +1,3 @@
-// import { test, expect } from '@playwright/test';
-//
-// test('test', async ({ page }) => {
-//   await page.goto('http://localhost:3000/');
-//   await page.getByRole('link', { name: '" counter(item) ". Blog' }).click();
-//   await page.getByLabel('Search').click();
-//   await page.getByPlaceholder('Search articles and').click();
-//   await page.getByPlaceholder('Search articles and').fill('vuejs');
-//   await page.getByText('FREE HOSTINGS for WEB').click();
-//   await page.goto('http://localhost:3000/posts/javascript-free-hosts');
-//   await page.getByRole('combobox').selectOption('/es/');
-//   await page.getByRole('link', { name: '" counter(item) ". Blog' }).click();
-//   await page.getByLabel('Buscar').click();
-//   await page.getByPlaceholder('Buscar artículos y').click();
-//   await page.getByPlaceholder('Buscar artículos y').fill('vuejs');
-//   await page.getByText('HOSTINGS GRATUITOS para').click();
-// });
-
 import { test, expect } from '@playwright/test';
 
 test('searchArticlesInEnglishAndSpanish', async ({ page }) => {

--- a/tests/integration/i18n-rss.spec.ts
+++ b/tests/integration/i18n-rss.spec.ts
@@ -11,22 +11,16 @@ test('test i18n and rss', async ({ page }) => {
 	expect(page.locator('p').first()).toHaveText('Hola, mi nombre es');
 
 	await expect(page.locator('h2:has-text("Sobre mí")')).toHaveText('Sobre mí');
-	await expect(page.locator('h2:has-text("Dónde he trabajado")')).toHaveText(
-		'Dónde he trabajado'
-	);
+	await expect(page.locator('h2:has-text("Dónde he trabajado")')).toHaveText('Dónde he trabajado');
 	await expect(page.locator('h2:has-text("Otros proyectos")')).toHaveText('Otros proyectos');
-	await expect(page.locator('h2:has-text("Últimos artículos")')).toHaveText(
-		'Últimos artículos'
-	);
+	await expect(page.locator('h2:has-text("Últimos artículos")')).toHaveText('Últimos artículos');
 	await expect(page.locator('h2:has-text("Contáctame")')).toHaveText('Contáctame');
 
 	await page.locator('select').nth(1).selectOption('/');
 	await expect(page).toHaveURL('http://localhost:3000');
 
 	await expect(page.locator('h2:has-text("About me")')).toHaveText('About me');
-	await expect(page.locator('h2:has-text("Where I\'ve Worked")')).toHaveText(
-		"Where I've Worked"
-	);
+	await expect(page.locator('h2:has-text("Where I\'ve Worked")')).toHaveText("Where I've Worked");
 	await expect(page.locator('h2:has-text("Other Noteworthy Projects")')).toHaveText(
 		'Other Noteworthy Projects'
 	);

--- a/tests/integration/i18n-rss.spec.ts
+++ b/tests/integration/i18n-rss.spec.ts
@@ -3,33 +3,33 @@ import { test, expect } from '@playwright/test';
 test('test i18n and rss', async ({ page }) => {
 	await page.goto('http://localhost:3000');
 
-	await expect(await page.locator('p').first()).toHaveText('Hi, my name is');
+	expect(page.locator('p').first()).toHaveText('Hi, my name is');
 
 	await page.locator('select').nth(1).selectOption('/es/');
 	await expect(page).toHaveURL('http://localhost:3000/es/');
 
-	expect(await page.locator('p').first()).toHaveText('Hola, mi nombre es');
+	expect(page.locator('p').first()).toHaveText('Hola, mi nombre es');
 
-	await expect(await page.locator('h2:has-text("Sobre mí")')).toHaveText('Sobre mí');
-	await expect(await page.locator('h2:has-text("Dónde he trabajado")')).toHaveText(
+	await expect(page.locator('h2:has-text("Sobre mí")')).toHaveText('Sobre mí');
+	await expect(page.locator('h2:has-text("Dónde he trabajado")')).toHaveText(
 		'Dónde he trabajado'
 	);
-	await expect(await page.locator('h2:has-text("Otros proyectos")')).toHaveText('Otros proyectos');
-	await expect(await page.locator('h2:has-text("Últimos artículos")')).toHaveText(
+	await expect(page.locator('h2:has-text("Otros proyectos")')).toHaveText('Otros proyectos');
+	await expect(page.locator('h2:has-text("Últimos artículos")')).toHaveText(
 		'Últimos artículos'
 	);
-	await expect(await page.locator('h2:has-text("Contáctame")')).toHaveText('Contáctame');
+	await expect(page.locator('h2:has-text("Contáctame")')).toHaveText('Contáctame');
 
 	await page.locator('select').nth(1).selectOption('/');
 	await expect(page).toHaveURL('http://localhost:3000');
 
-	await expect(await page.locator('h2:has-text("About me")')).toHaveText('About me');
-	await expect(await page.locator('h2:has-text("Where I\'ve Worked")')).toHaveText(
+	await expect(page.locator('h2:has-text("About me")')).toHaveText('About me');
+	await expect(page.locator('h2:has-text("Where I\'ve Worked")')).toHaveText(
 		"Where I've Worked"
 	);
-	await expect(await page.locator('h2:has-text("Other Noteworthy Projects")')).toHaveText(
+	await expect(page.locator('h2:has-text("Other Noteworthy Projects")')).toHaveText(
 		'Other Noteworthy Projects'
 	);
-	await expect(await page.locator('h2:has-text("Last Articles")')).toHaveText('Last Articles');
-	await expect(await page.locator('h2:has-text("Contact me")')).toHaveText('Contact me');
+	await expect(page.locator('h2:has-text("Last Articles")')).toHaveText('Last Articles');
+	await expect(page.locator('h2:has-text("Contact me")')).toHaveText('Contact me');
 });


### PR DESCRIPTION
This pull request includes significant changes to the Netlify CMS configuration and content collections to improve multilingual support and simplify the configuration structure. The most important changes include renaming and updating collections, modifying configuration imports, and ensuring required fields.

### Netlify CMS Configuration and Collections:

* [`astro.config.ts`](diffhunk://#diff-baf06eda15601b59413c77e1f18884403033204061e6c9408cd9a3bb5bc6e586L9-R9): Changed the import of `cmsConfig` and updated the `NetlifyCMS` configuration to use `cmsConfig` instead of `config`. [[1]](diffhunk://#diff-baf06eda15601b59413c77e1f18884403033204061e6c9408cd9a3bb5bc6e586L9-R9) [[2]](diffhunk://#diff-baf06eda15601b59413c77e1f18884403033204061e6c9408cd9a3bb5bc6e586L38-R38)
* [`src/plugins/netlify-cms.ts`](diffhunk://#diff-8035f3ae46eab69af700099a815a081cc8cc40f0368e1a1a9f5e819cce5468a5L2-R18): Simplified the configuration by importing collections directly from language-specific files and combining them into a single `config` object. Also updated the branch name and media folder paths.

### Content Collections:

* [`src/plugins/netlify-cms-en.ts`](diffhunk://#diff-19f5e5502d3b027d778739d35e35a4f3788bf11897b9c2488e772feabc773f9aL5-R11): Renamed collections to include the language suffix, added language filters, and ensured required fields for English content. [[1]](diffhunk://#diff-19f5e5502d3b027d778739d35e35a4f3788bf11897b9c2488e772feabc773f9aL5-R11) [[2]](diffhunk://#diff-19f5e5502d3b027d778739d35e35a4f3788bf11897b9c2488e772feabc773f9aR24) [[3]](diffhunk://#diff-19f5e5502d3b027d778739d35e35a4f3788bf11897b9c2488e772feabc773f9aL66-R74) [[4]](diffhunk://#diff-19f5e5502d3b027d778739d35e35a4f3788bf11897b9c2488e772feabc773f9aL99-R108)
* [`src/plugins/netlify-cms-es.ts`](diffhunk://#diff-64785fa087b6af397915038bfdcd15958245f96e24f0c869006956508fbacaa9L5-R11): Renamed collections to include the language suffix, added language filters, and ensured required fields for Spanish content. [[1]](diffhunk://#diff-64785fa087b6af397915038bfdcd15958245f96e24f0c869006956508fbacaa9L5-R11) [[2]](diffhunk://#diff-64785fa087b6af397915038bfdcd15958245f96e24f0c869006956508fbacaa9R24)