### PR TITLE
chore: Update SonarCloud action version in workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -33,7 +33,7 @@ jobs:
 
         # You can pin the exact commit or the version.
         # uses: SonarSource/sonarcloud-github-action@de2e56b42aa84d0b1c5b622644ac17e505c9a049
-        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19
+        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8
         env:
           GITHUB_TOKEN: ${{ env.PBOT_GITHUB_TOKEN }} # Needed to get PR information
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)


### PR DESCRIPTION
This pull request makes a minor update to the SonarCloud GitHub Action used in the workflow configuration, upgrading it to a newer commit version.

- Upgraded the `SonarSource/sonarcloud-github-action` in `.github/workflows/sonarcloud.yml` to use commit `ffc3010689be73b8e5ae0c57ce35968afd7909e8` instead of the previous version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI to use a newer SonarCloud analysis action, improving reliability and security of code quality checks.
  * Refreshed the pinned version in our GitHub workflow to incorporate upstream fixes and enhancements.
  * No changes to application features, UI, or performance.
  * Build, test, and deployment behavior remain unchanged for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->