### PR TITLE
fix(i18n): provide default locale on 404 page

### DIFF
--- a/apps/portfolio/src/pages/404.astro
+++ b/apps/portfolio/src/pages/404.astro
@@ -4,7 +4,7 @@ export const prerender = true;
 import { Image } from "astro:assets";
 import Container from "@/components/atoms/Container.astro";
 import { useTranslations } from "@/i18n";
-import { type Lang } from "@/i18n/types";
+import { DEFAULT_LOCALE, type Lang } from "@/i18n/types";
 /**
  * This page is displayed when a user navigates to a URL that does not exist.
  * It shows a 404 "Not Found" error message and provides a link back to the homepage.
@@ -12,7 +12,7 @@ import { type Lang } from "@/i18n/types";
 import Layout from "@/layouts/Layout.astro";
 import oops from "../../public/oops.webp";
 
-const t = useTranslations(Astro.currentLocale as Lang);
+const t = useTranslations((Astro.currentLocale as Lang) || DEFAULT_LOCALE);
 ---
 
 <Layout title={t("404.title")}>


### PR DESCRIPTION
On the 404 page, `Astro.currentLocale` can be `undefined`, which causes issues with the i18n module. This change provides a default locale as a fallback to ensure that the translation functions always receive a valid language, which fixes the broken links in the header and other components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale fallback handling on error pages to ensure translations display reliably even when locale resolution encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->