### PR TITLE
refactor(layout): 🔧 replace Footer with BlogFooter component

### DIFF
--- a/apps/portfolio/src/components/atoms/SearchButton.astro
+++ b/apps/portfolio/src/components/atoms/SearchButton.astro
@@ -4,6 +4,7 @@ import { Icon } from "astro-icon/components";
 import {
 	DEFAULT_LOCALE,
 	type Lang,
+	LOCALES,
 	useTranslatedPath,
 	useTranslations,
 } from "@/i18n";

--- a/apps/portfolio/src/components/atoms/SearchButton.astro
+++ b/apps/portfolio/src/components/atoms/SearchButton.astro
@@ -12,10 +12,13 @@ import { cn } from "@/lib/utils";
 interface Props extends HTMLAttributes<"a"> {
 	class?: string;
 }
-const currentLocale =
+const localeSegment = Astro.url.pathname.split("/")[1];
+const validLocales = Object.keys(LOCALES);
+const resolvedLocale =
 	Astro.params.lang ||
-	(Astro.url.pathname.split("/")[1] as Lang) ||
+	(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
 	DEFAULT_LOCALE;
+const currentLocale = resolvedLocale;
 const t = useTranslations(currentLocale);
 const translatePath = useTranslatedPath(currentLocale);
 const { class: className, ...props } = Astro.props;

--- a/apps/portfolio/src/components/atoms/SearchButton.astro
+++ b/apps/portfolio/src/components/atoms/SearchButton.astro
@@ -1,25 +1,14 @@
 ---
 import type { HTMLAttributes } from "astro/types";
 import { Icon } from "astro-icon/components";
-import {
-	DEFAULT_LOCALE,
-	type Lang,
-	LOCALES,
-	useTranslatedPath,
-	useTranslations,
-} from "@/i18n";
+import { useTranslatedPath, useTranslations } from "@/i18n";
+import { resolveLocaleFromUrl } from "@/i18n/utils/resolveLocaleFromUrl";
 import { cn } from "@/lib/utils";
 
 interface Props extends HTMLAttributes<"a"> {
 	class?: string;
 }
-const localeSegment = Astro.url.pathname.split("/")[1];
-const validLocales = Object.keys(LOCALES);
-const resolvedLocale =
-	Astro.params.lang ||
-	(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
-	DEFAULT_LOCALE;
-const currentLocale = resolvedLocale;
+const currentLocale = resolveLocaleFromUrl(Astro.url, Astro.params.lang);
 const t = useTranslations(currentLocale);
 const translatePath = useTranslatedPath(currentLocale);
 const { class: className, ...props } = Astro.props;

--- a/apps/portfolio/src/components/molecules/Menu.astro
+++ b/apps/portfolio/src/components/molecules/Menu.astro
@@ -7,6 +7,7 @@ import { navMenus } from "@/core/menu";
 import {
 	DEFAULT_LOCALE,
 	type Lang,
+	LOCALES,
 	useTranslatedPath,
 	useTranslations,
 } from "@/i18n";

--- a/apps/portfolio/src/components/molecules/Menu.astro
+++ b/apps/portfolio/src/components/molecules/Menu.astro
@@ -26,13 +26,9 @@ const {
 	...props
 } = Astro.props;
 
-const localeSegment = Astro.url.pathname.split("/")[1];
-const validLocales = Object.keys(LOCALES);
-const resolvedLocale =
-	Astro.params.lang ||
-	(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
-	DEFAULT_LOCALE;
-const currentLocale = resolvedLocale;
+import { resolveLocaleFromUrl } from "@/i18n/utils/resolveLocaleFromUrl";
+
+const currentLocale = resolveLocaleFromUrl(Astro.url, Astro.params.lang);
 const t = useTranslations(currentLocale);
 const translatePath = useTranslatedPath(currentLocale);
 ---

--- a/apps/portfolio/src/components/molecules/Menu.astro
+++ b/apps/portfolio/src/components/molecules/Menu.astro
@@ -25,160 +25,167 @@ const {
 	...props
 } = Astro.props;
 
-const currentLocale =
+const localeSegment = Astro.url.pathname.split("/")[1];
+const validLocales = Object.keys(LOCALES);
+const resolvedLocale =
 	Astro.params.lang ||
-	(Astro.url.pathname.split("/")[1] as Lang) ||
+	(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
 	DEFAULT_LOCALE;
+const currentLocale = resolvedLocale;
 const t = useTranslations(currentLocale);
 const translatePath = useTranslatedPath(currentLocale);
 ---
 
 <nav
-  aria-label={t("mainNavigation")}
-  class={cn(
-    "mt-8 w-full origin-top-right items-center",
-    "space-y-6 overflow-x-hidden overflow-y-auto font-medium tracking-wide lg:mt-0 lg:flex",
-    "lg:w-auto lg:space-x-0 lg:space-y-0 flex-shrink-0",
-    "safari-nav-fix",
-    className
-  )}
-  {...props}
+	aria-label={t("mainNavigation")}
+	class={cn(
+		"mt-8 w-full origin-top-right items-center",
+		"space-y-6 overflow-x-hidden overflow-y-auto font-medium tracking-wide lg:mt-0 lg:flex",
+		"lg:w-auto lg:space-x-0 lg:space-y-0 flex-shrink-0",
+		"safari-nav-fix",
+		className,
+	)}
+	{...props}
 >
-  <ul class="flex items-center lg:gap-8 order-list safari-menu-list">
-    {navMenus.map((menu) => (
-      <li>
-        <a
-          href={translatePath(menu.link)}
-          id={drawer ? `drawer-${menu.id}` : `nav-${menu.id}`}
-          data-drawer-dismiss={drawer ? "drawer-menu" : undefined}
-          aria-current={Astro.url.pathname.startsWith(menu.link) ? "page" : undefined}
-          class="nav-link"
-        >
-          {t(menu.title)}
-        </a>
-      </li>
-    ))}
-  </ul>
+	<ul class="flex items-center lg:gap-8 order-list safari-menu-list">
+		{
+			navMenus.map((menu) => (
+				<li>
+					<a
+						href={translatePath(menu.link)}
+						id={drawer ? `drawer-${menu.id}` : `nav-${menu.id}`}
+						data-drawer-dismiss={drawer ? "drawer-menu" : undefined}
+						aria-current={
+							Astro.url.pathname.startsWith(menu.link) ? "page" : undefined
+						}
+						class="nav-link"
+					>
+						{t(menu.title)}
+					</a>
+				</li>
+			))
+		}
+	</ul>
 
-  <div class="flex items-center lg:gap-2 safari-actions-container">
-    <LocaleSelect
-      class="px-3 py-1 text-sm text-foreground-muted hover:text-brand-accent transition-all duration-200 font-display"
-    />
-    <a
-      class="rounded bg-transparent p-2 text-sm text-foreground-muted hover:text-brand-accent hover:bg-brand-accent/10 transition-all duration-200 border border-transparent hover:border-brand-accent"
-      aria-label={t("rssFeed")}
-      target="_blank"
-      href={translatePath("/rss.xml")}
-    >
-      <Icon name="lucide:rss" class="h-5 w-5" aria-hidden="true" />
-    </a>
-    <ThemeToggle currentLocale={currentLocale} />
-    <ResumeButton
-      resumePath={resumePath}
-      variant="primary"
-      currentLocale={currentLocale}
-      class="w-full flex items-center justify-center gap-2"
-    />
-  </div>
+	<div class="flex items-center lg:gap-2 safari-actions-container">
+		<LocaleSelect
+			class="px-3 py-1 text-sm text-foreground-muted hover:text-brand-accent transition-all duration-200 font-display"
+		/>
+		<a
+			class="rounded bg-transparent p-2 text-sm text-foreground-muted hover:text-brand-accent hover:bg-brand-accent/10 transition-all duration-200 border border-transparent hover:border-brand-accent"
+			aria-label={t("rssFeed")}
+			target="_blank"
+			href={translatePath("/rss.xml")}
+		>
+			<Icon name="lucide:rss" class="h-5 w-5" aria-hidden="true" />
+		</a>
+		<ThemeToggle currentLocale={currentLocale} />
+		<ResumeButton
+			resumePath={resumePath}
+			variant="primary"
+			currentLocale={currentLocale}
+			class="w-full flex items-center justify-center gap-2"
+		/>
+	</div>
 </nav>
 
 <style>
-  /* Safari-specific fixes for menu navigation */
-  nav.safari-nav-fix {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-    -webkit-flex-direction: row;
-    flex-direction: column;
-  }
+	/* Safari-specific fixes for menu navigation */
+	nav.safari-nav-fix {
+		-webkit-box-orient: horizontal;
+		-webkit-box-direction: normal;
+		-webkit-flex-direction: row;
+		flex-direction: column;
+	}
 
-  @media (min-width: 1024px) {
-    nav.safari-nav-fix {
-      display: -webkit-box;
-      display: -webkit-flex;
-      display: flex;
-      -webkit-box-orient: horizontal;
-      -webkit-box-direction: normal;
-      -webkit-flex-direction: row;
-      flex-direction: row;
-      -webkit-box-align: center;
-      -webkit-align-items: center;
-      align-items: center;
-      width: auto;
-      max-width: 100%;
-      -webkit-box-flex: 0;
-      -webkit-flex: 0 0 auto;
-      flex: 0 0 auto;
-    }
-  }
+	@media (min-width: 1024px) {
+		nav.safari-nav-fix {
+			display: -webkit-box;
+			display: -webkit-flex;
+			display: flex;
+			-webkit-box-orient: horizontal;
+			-webkit-box-direction: normal;
+			-webkit-flex-direction: row;
+			flex-direction: row;
+			-webkit-box-align: center;
+			-webkit-align-items: center;
+			align-items: center;
+			width: auto;
+			max-width: 100%;
+			-webkit-box-flex: 0;
+			-webkit-flex: 0 0 auto;
+			flex: 0 0 auto;
+		}
+	}
 
-  /* Safari flexbox list fix with explicit margins as fallback for gap */
-  .safari-menu-list {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-box-align: center;
-    -webkit-align-items: center;
-    align-items: center;
-  }
+	/* Safari flexbox list fix with explicit margins as fallback for gap */
+	.safari-menu-list {
+		display: -webkit-box;
+		display: -webkit-flex;
+		display: flex;
+		-webkit-box-align: center;
+		-webkit-align-items: center;
+		align-items: center;
+	}
 
-  .safari-menu-list li {
-    margin-right: 2rem;
-  }
+	.safari-menu-list li {
+		margin-right: 2rem;
+	}
 
-  .safari-menu-list li:last-child {
-    margin-right: 0;
-  }
+	.safari-menu-list li:last-child {
+		margin-right: 0;
+	}
 
-  @media (min-width: 1024px) {
-    .safari-menu-list {
-      gap: 2rem;
-    }
+	@media (min-width: 1024px) {
+		.safari-menu-list {
+			gap: 2rem;
+		}
 
-    /* Reset margin when gap is supported */
-    @supports (gap: 2rem) {
-      .safari-menu-list li {
-        margin-right: 0;
-      }
-    }
-  }
+		/* Reset margin when gap is supported */
+		@supports (gap: 2rem) {
+			.safari-menu-list li {
+				margin-right: 0;
+			}
+		}
+	}
 
-  /* Safari actions container with margin fallback */
-  .safari-actions-container {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-box-align: center;
-    -webkit-align-items: center;
-    align-items: center;
-  }
+	/* Safari actions container with margin fallback */
+	.safari-actions-container {
+		display: -webkit-box;
+		display: -webkit-flex;
+		display: flex;
+		-webkit-box-align: center;
+		-webkit-align-items: center;
+		align-items: center;
+	}
 
-  .safari-actions-container > * {
-    margin-right: 0.5rem;
-  }
+	.safari-actions-container > * {
+		margin-right: 0.5rem;
+	}
 
-  .safari-actions-container > *:last-child {
-    margin-right: 0;
-  }
+	.safari-actions-container > *:last-child {
+		margin-right: 0;
+	}
 
-  @media (min-width: 1024px) {
-    .safari-actions-container {
-      gap: 0.5rem;
-    }
+	@media (min-width: 1024px) {
+		.safari-actions-container {
+			gap: 0.5rem;
+		}
 
-    /* Reset margin when gap is supported */
-    @supports (gap: 0.5rem) {
-      .safari-actions-container > * {
-        margin-right: 0;
-      }
-    }
-  }
+		/* Reset margin when gap is supported */
+		@supports (gap: 0.5rem) {
+			.safari-actions-container > * {
+				margin-right: 0;
+			}
+		}
+	}
 
-  /* Prevent unwanted scroll in Safari */
-  @media (min-width: 1024px) {
-    nav.safari-nav-fix {
-      overflow-x: hidden;
-      overflow-y: visible;
-      -webkit-overflow-scrolling: touch;
-    }
-  }
+	/* Prevent unwanted scroll in Safari */
+	@media (min-width: 1024px) {
+		nav.safari-nav-fix {
+			overflow-x: hidden;
+			overflow-y: visible;
+			-webkit-overflow-scrolling: touch;
+		}
+	}
 </style>

--- a/apps/portfolio/src/components/organisms/Header.astro
+++ b/apps/portfolio/src/components/organisms/Header.astro
@@ -29,13 +29,9 @@ const {
 	...attrs
 } = Astro.props;
 
-const localeSegment = Astro.url.pathname.split("/")[1];
-const validLocales = Object.keys(LOCALES);
-const resolvedLocale =
-	Astro.params.lang ||
-	(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
-	DEFAULT_LOCALE;
-const currentLocale = resolvedLocale;
+import { resolveLocaleFromUrl } from "@/i18n/utils/resolveLocaleFromUrl";
+
+const currentLocale = resolveLocaleFromUrl(Astro.url, Astro.params.lang);
 const t = useTranslations(currentLocale);
 ---
 

--- a/apps/portfolio/src/components/organisms/Header.astro
+++ b/apps/portfolio/src/components/organisms/Header.astro
@@ -1,13 +1,12 @@
 ---
 import type { HTMLAttributes } from "astro/types";
-import { Icon } from "astro-icon/components";
 import Logo from "@/components/atoms/Logo.astro";
 import MobileMenuButton from "@/components/atoms/MobileMenuButton.astro";
 import Menu from "@/components/molecules/Menu.astro";
 import MobileDrawer from "@/components/organisms/MobileDrawer.astro";
 import { HEADER_ID } from "@/configs/theme.consts";
 import { DRAWER_MENU_BUTTON_BOX_ID } from "@/core/menu/menu.constants";
-import { DEFAULT_LOCALE, type Lang, useTranslations } from "@/i18n";
+import { DEFAULT_LOCALE, LOCALES, useTranslations } from "@/i18n";
 import { cn } from "@/lib/utils";
 import SearchButton from "../atoms/SearchButton.astro";
 

--- a/apps/portfolio/src/components/organisms/Header.astro
+++ b/apps/portfolio/src/components/organisms/Header.astro
@@ -30,10 +30,13 @@ const {
 	...attrs
 } = Astro.props;
 
-const currentLocale =
+const localeSegment = Astro.url.pathname.split("/")[1];
+const validLocales = Object.keys(LOCALES);
+const resolvedLocale =
 	Astro.params.lang ||
-	(Astro.url.pathname.split("/")[1] as Lang) ||
+	(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
 	DEFAULT_LOCALE;
+const currentLocale = resolvedLocale;
 const t = useTranslations(currentLocale);
 ---
 

--- a/apps/portfolio/src/components/organisms/MobileDrawer.astro
+++ b/apps/portfolio/src/components/organisms/MobileDrawer.astro
@@ -2,7 +2,13 @@
 import ResumeButton from "@/components/atoms/ResumeButton.astro";
 import ThemeToggle from "@/components/atoms/ThemeToggle.astro";
 import { navMenus } from "@/core/menu";
-import { DEFAULT_LOCALE, type Lang, useTranslatedPath, useTranslations } from "@/i18n";
+import {
+	DEFAULT_LOCALE,
+	type Lang,
+	LOCALES,
+	useTranslatedPath,
+	useTranslations,
+} from "@/i18n";
 import LocaleSelect from "@/i18n/components/LocaleSelect.astro";
 import { cn } from "@/lib/utils";
 import SearchButton from "../atoms/SearchButton.astro";
@@ -21,10 +27,14 @@ const {
 	showSearch = false,
 } = Astro.props;
 
-const currentLocale =
+// Validate locale segment from URL
+const localeSegment = Astro.url.pathname.split("/")[1];
+const validLocales = Object.keys(LOCALES);
+const resolvedLocale =
 	Astro.params.lang ||
-	(Astro.url.pathname.split("/")[1] as Lang) ||
+	(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
 	DEFAULT_LOCALE;
+const currentLocale = resolvedLocale;
 const t = useTranslations(currentLocale);
 const translatePath = useTranslatedPath(currentLocale);
 ---
@@ -34,22 +44,23 @@ const translatePath = useTranslatedPath(currentLocale);
 	id="mobile-drawer-backdrop"
 	class="fixed inset-0 bg-black/50 backdrop-blur-sm z-30 hidden opacity-0 transition-opacity duration-300"
 	aria-hidden="true"
-></div>
+>
+</div>
 
 <!-- Drawer -->
 <aside
-       id={id}
-	   class={cn(
-		   "fixed top-0 right-0 z-60 h-screen w-80 max-w-[90vw]",
-		   "bg-background border-l border-border shadow-2xl",
-		   "transform translate-x-full transition-transform duration-300 ease-in-out",
-		   "overflow-y-auto scrollbar-thin",
-		   className
-	   )}
-       aria-label={t("nav.mobile") || "Mobile navigation"}
-       aria-hidden="true"
-       role="dialog"
-       aria-modal="true"
+	id={id}
+	class={cn(
+		"fixed top-0 right-0 z-60 h-screen w-80 max-w-[90vw]",
+		"bg-background border-l border-border shadow-2xl",
+		"transform translate-x-full transition-transform duration-300 ease-in-out",
+		"overflow-y-auto scrollbar-thin",
+		className,
+	)}
+	aria-label={t("nav.mobile") || "Mobile navigation"}
+	aria-hidden="true"
+	role="dialog"
+	aria-modal="true"
 >
 	<!-- Header -->
 	<div class="p-4 border-b border-border">
@@ -61,30 +72,34 @@ const translatePath = useTranslatedPath(currentLocale);
 	<!-- Navigation -->
 	<nav class="p-4" aria-label={t("nav.main") || "Main navigation"}>
 		<!-- Search Box -->
-		{showSearch && (
-			<div class="mb-4 pb-4 border-b border-border">
-				<SearchButton />
-			</div>
-		)}
+		{
+			showSearch && (
+				<div class="mb-4 pb-4 border-b border-border">
+					<SearchButton />
+				</div>
+			)
+		}
 
 		<ul class="space-y-4">
-			{navMenus.map((menu) => (
-				<li>
-					<a
-						href={translatePath(menu.link)}
-						class="flex items-center px-3 py-2 rounded-md text-foreground transition-colors focus-visible:outline-2 focus-visible:outline-brand-accent hover:bg-brand-accent/10 hover:text-brand-accent dark:hover:bg-brand-accent/20 dark:hover:text-brand-accent"
-						data-drawer-close
-						tabindex="0"
-					>
-						<span class="font-medium">{t(menu.title)}</span>
-					</a>
-				</li>
-			))}
+			{
+				navMenus.map((menu) => (
+					<li>
+						<a
+							href={translatePath(menu.link)}
+							class="flex items-center px-3 py-2 rounded-md text-foreground transition-colors focus-visible:outline-2 focus-visible:outline-brand-accent hover:bg-brand-accent/10 hover:text-brand-accent dark:hover:bg-brand-accent/20 dark:hover:text-brand-accent"
+							data-drawer-close
+							tabindex="0"
+						>
+							<span class="font-medium">{t(menu.title)}</span>
+						</a>
+					</li>
+				))
+			}
 		</ul>
 
 		<!-- Resume Download -->
 		<div class="mt-6 pt-4 border-t border-border">
-			<ResumeButton 
+			<ResumeButton
 				resumePath={resumePath}
 				fullWidth
 				currentLocale={currentLocale}
@@ -99,10 +114,7 @@ const translatePath = useTranslatedPath(currentLocale);
 				<div class="block text-sm font-medium text-foreground-muted">
 					{t("nav.language") || "Language"}
 				</div>
-				<LocaleSelect 
-					class="w-full"
-					variant="text"
-				/>
+				<LocaleSelect class="w-full" variant="text" />
 			</div>
 
 			<!-- Theme Toggle -->
@@ -111,7 +123,7 @@ const translatePath = useTranslatedPath(currentLocale);
 					{t("nav.theme") || "Theme"}
 				</div>
 				<div class="flex justify-start">
-					<ThemeToggle 
+					<ThemeToggle
 						currentLocale={currentLocale}
 						showText={true}
 						class="w-full justify-start text-left"

--- a/apps/portfolio/src/components/organisms/MobileDrawer.astro
+++ b/apps/portfolio/src/components/organisms/MobileDrawer.astro
@@ -2,7 +2,7 @@
 import ResumeButton from "@/components/atoms/ResumeButton.astro";
 import ThemeToggle from "@/components/atoms/ThemeToggle.astro";
 import { navMenus } from "@/core/menu";
-import { type Lang, useTranslatedPath, useTranslations } from "@/i18n";
+import { DEFAULT_LOCALE, type Lang, useTranslatedPath, useTranslations } from "@/i18n";
 import LocaleSelect from "@/i18n/components/LocaleSelect.astro";
 import { cn } from "@/lib/utils";
 import SearchButton from "../atoms/SearchButton.astro";
@@ -21,7 +21,10 @@ const {
 	showSearch = false,
 } = Astro.props;
 
-const currentLocale = Astro.params.lang as Lang;
+const currentLocale =
+	Astro.params.lang ||
+	(Astro.url.pathname.split("/")[1] as Lang) ||
+	DEFAULT_LOCALE;
 const t = useTranslations(currentLocale);
 const translatePath = useTranslatedPath(currentLocale);
 ---

--- a/apps/portfolio/src/components/organisms/MobileDrawer.astro
+++ b/apps/portfolio/src/components/organisms/MobileDrawer.astro
@@ -27,14 +27,9 @@ const {
 	showSearch = false,
 } = Astro.props;
 
-// Validate locale segment from URL
-const localeSegment = Astro.url.pathname.split("/")[1];
-const validLocales = Object.keys(LOCALES);
-const resolvedLocale =
-	Astro.params.lang ||
-	(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
-	DEFAULT_LOCALE;
-const currentLocale = resolvedLocale;
+import { resolveLocaleFromUrl } from "@/i18n/utils/resolveLocaleFromUrl";
+
+const currentLocale = resolveLocaleFromUrl(Astro.url, Astro.params.lang);
 const t = useTranslations(currentLocale);
 const translatePath = useTranslatedPath(currentLocale);
 ---

--- a/apps/portfolio/src/i18n/utils/resolveLocaleFromUrl.ts
+++ b/apps/portfolio/src/i18n/utils/resolveLocaleFromUrl.ts
@@ -5,9 +5,9 @@ import { DEFAULT_LOCALE, type Lang, LOCALES } from "@/i18n";
  * Ensures only valid locales are returned, falling back to DEFAULT_LOCALE.
  */
 export function resolveLocaleFromUrl(url: URL, paramsLang?: string): Lang {
-    const localeSegment = url.pathname.split("/")[1];
-    const validLocales = Object.keys(LOCALES);
-    return (paramsLang ||
-        (validLocales.includes(localeSegment) ? localeSegment : undefined) ||
-        DEFAULT_LOCALE) as Lang;
+	const localeSegment = url.pathname.split("/")[1];
+	const validLocales = Object.keys(LOCALES);
+	return (paramsLang ||
+		(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
+		DEFAULT_LOCALE) as Lang;
 }

--- a/apps/portfolio/src/i18n/utils/resolveLocaleFromUrl.ts
+++ b/apps/portfolio/src/i18n/utils/resolveLocaleFromUrl.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_LOCALE, type Lang, LOCALES } from "@/i18n";
+
+/**
+ * Resolves the current locale from the URL and optional params.lang.
+ * Ensures only valid locales are returned, falling back to DEFAULT_LOCALE.
+ */
+export function resolveLocaleFromUrl(url: URL, paramsLang?: string): Lang {
+    const localeSegment = url.pathname.split("/")[1];
+    const validLocales = Object.keys(LOCALES);
+    return (paramsLang ||
+        (validLocales.includes(localeSegment) ? localeSegment : undefined) ||
+        DEFAULT_LOCALE) as Lang;
+}

--- a/apps/portfolio/src/layouts/Page.astro
+++ b/apps/portfolio/src/layouts/Page.astro
@@ -1,8 +1,8 @@
 ---
-import Footer from "@/components/organisms/Footer.astro";
 import Header from "@/components/organisms/Header.astro";
 import LocaleSuggest from "@/i18n/components/LocaleSuggest.astro";
 import Layout from "./Layout.astro";
+import BlogFooter from "@/components/organisms/BlogFooter.astro";
 
 interface Props {
 	title?: string;
@@ -22,5 +22,5 @@ const { title, description } = Astro.props.frontmatter || Astro.props;
 	<div class="container mx-auto px-4 pt-24 prose lg:prose-xl xl:prose-2xl dark:prose-invert" data-pagefind-body>
 		<slot />
 	</div>
-  <Footer />
+ 	<BlogFooter />
 </Layout>

--- a/apps/portfolio/src/layouts/Page.astro
+++ b/apps/portfolio/src/layouts/Page.astro
@@ -1,5 +1,5 @@
 ---
-import Footer from "@/components/organisms/Footer.astro";
+import BlogFooter from "@/components/organisms/BlogFooter.astro";
 import Header from "@/components/organisms/Header.astro";
 import LocaleSuggest from "@/i18n/components/LocaleSuggest.astro";
 import Layout from "./Layout.astro";
@@ -22,5 +22,5 @@ const { title, description } = Astro.props.frontmatter || Astro.props;
 	<div class="container mx-auto px-4 pt-24 prose lg:prose-xl xl:prose-2xl dark:prose-invert" data-pagefind-body>
 		<slot />
 	</div>
-  <Footer />
+ 	<BlogFooter />
 </Layout>

--- a/apps/portfolio/src/layouts/Page.astro
+++ b/apps/portfolio/src/layouts/Page.astro
@@ -16,11 +16,14 @@ const { title, description } = Astro.props.frontmatter || Astro.props;
 <Layout {title} {description}>
 	<slot name="header" slot="header">
 		<LocaleSuggest />
-    <Header />
+		<Header />
 	</slot>
 	<slot name="subheader" slot="subheader" />
-	<div class="container mx-auto px-4 pt-24 prose lg:prose-xl xl:prose-2xl dark:prose-invert" data-pagefind-body>
+	<div
+		class="container mx-auto px-4 pt-24 prose lg:prose-xl xl:prose-2xl dark:prose-invert"
+		data-pagefind-body
+	>
 		<slot />
 	</div>
- 	<BlogFooter />
+	<BlogFooter />
 </Layout>


### PR DESCRIPTION
This pull request updates the page layout in the portfolio app to use a new footer component. The main change is the replacement of the existing `Footer` with `BlogFooter` in the `Page.astro` layout.

Component changes:

* Replaced the import of `Footer` with `BlogFooter` in `apps/portfolio/src/layouts/Page.astro`.
* Updated the layout to render `BlogFooter` instead of `Footer` at the bottom of the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Portfolio now uses the blog-styled footer, updating footer appearance and content.
  * Navigation, header, search button, and mobile drawer markup reworked for more consistent rendering, accessibility, and UI behavior.

* **Bug Fix**
  * Improved locale detection across header, navigation, search, and mobile menu so language selection validates path locales and reliably falls back to the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->