### PR TITLE
feat: Optimize tests and fix build

### DIFF
--- a/apps/portfolio/playwright.config.ts
+++ b/apps/portfolio/playwright.config.ts
@@ -34,9 +34,9 @@ export default defineConfig({
 	// Global configuration for all tests
 	use: {
 		baseURL: process.env.BASE_URL || "http://localhost:4322",
-		trace: "retain-on-failure",
-		screenshot: "only-on-failure",
-		video: "retain-on-failure",
+		trace: "off",
+		screenshot: "off",
+		video: "off",
 		viewport: { width: 1280, height: 720 },
 		colorScheme: "light",
 		ignoreHTTPSErrors: true,


### PR DESCRIPTION
This commit optimizes the test suite for faster execution, and fixes the `check` and `build` commands.

- Disabled video recording, screenshots, and trace viewers in the Playwright configuration to improve test performance.
- Increased the memory limit for the `check:astro` command to prevent out-of-memory errors.

Note: The e2e test suite is still timing out in the execution environment, but the `check` and `build` commands now pass successfully.