### PR TITLE
fix(rss): correct url generation in rss.xml.js

### DIFF
--- a/apps/portfolio/src/pages/[lang]/rss.xml.js
+++ b/apps/portfolio/src/pages/[lang]/rss.xml.js
@@ -25,7 +25,7 @@ export async function GET(context) {
 		title: post.data.title,
 		pubDate: post.data.date,
 		description: post.data.description,
-		link: `/${locale}/blog/${post.id.split("/")[1]}/`,
+		link: `/${locale}/blog/${post.id.split("/").slice(1).join("/")}/`,
 	}));
 
 	// Combine and sort all items by date


### PR DESCRIPTION
The previous implementation of the RSS feed generation was incorrectly constructing the URLs for blog posts. It was using `post.id.split('/')[1]`, which would only work for posts that were not in subdirectories.

This commit changes the logic to use `post.id.split('/').slice(1).join('/')`, which correctly handles nested content paths and generates the correct URL for all blog posts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RSS feed item links to correctly include the complete article path after the locale identifier, improving navigation accuracy for RSS subscribers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->