### PR TITLE
fix(e2e): stabilize monorepo playwright runs across apps

### DIFF
--- a/apps/blog/astro.config.mjs
+++ b/apps/blog/astro.config.mjs
@@ -6,7 +6,10 @@ import { defineConfig, sharpImageService } from "astro/config";
 import critters from "astro-critters";
 import icon from "astro-icon";
 import pagefind from "astro-pagefind";
-import { DEFAULT_LOCALE_SETTING, LOCALES_SETTING } from "../../packages/shared/src/i18n/locales.ts";
+import {
+	DEFAULT_LOCALE_SETTING,
+	LOCALES_SETTING,
+} from "../../packages/shared/src/i18n/locales.ts";
 import envSchema from "../../packages/shared/src/utils/env-schema.ts";
 import { whenExternalScripts } from "../../packages/shared/src/utils/externalScripts.ts";
 import {

--- a/apps/blog/playwright.config.ts
+++ b/apps/blog/playwright.config.ts
@@ -6,6 +6,7 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
 	testDir: "tests/e2e",
+	testIgnore: ["tests/e2e/contact-form.spec.ts"],
 
 	// Test execution settings
 	timeout: 120_000, // Increased timeout for webkit stability

--- a/apps/blog/src/content.config.ts
+++ b/apps/blog/src/content.config.ts
@@ -23,7 +23,10 @@ const locationSchema = z.object({
 
 // System skills library collection (icons, metadata, etc.)
 const skillsLibrary = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.json", base: "../../packages/shared/src/data/skills" }),
+	loader: glob({
+		pattern: "**/[^_]*.json",
+		base: "../../packages/shared/src/data/skills",
+	}),
 	schema: z.object({
 		id: z.string(),
 		name: z.string(),
@@ -33,7 +36,10 @@ const skillsLibrary = defineCollection({
 
 // Languages library collection (language names, mappings, metadata)
 const languagesLibrary = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.json", base: "../../packages/shared/src/data/languages" }),
+	loader: glob({
+		pattern: "**/[^_]*.json",
+		base: "../../packages/shared/src/data/languages",
+	}),
 	schema: z.object({
 		code: z.string(),
 		nativeName: z.string(),
@@ -66,7 +72,10 @@ const projectMetadata = defineCollection({
 
 // Main resume collection using glob loader for multiple languages
 const resume = defineCollection({
-	loader: glob({ pattern: "**/resume.json", base: "../../packages/shared/src/data/resume" }),
+	loader: glob({
+		pattern: "**/resume.json",
+		base: "../../packages/shared/src/data/resume",
+	}),
 	schema: z.object({
 		basics: z.object({
 			name: z.string(),
@@ -209,7 +218,10 @@ const resume = defineCollection({
 });
 
 const articles = defineCollection({
-	loader: glob({ pattern: "**/*.{md,mdx}", base: "../../packages/shared/src/data/articles" }),
+	loader: glob({
+		pattern: "**/*.{md,mdx}",
+		base: "../../packages/shared/src/data/articles",
+	}),
 	schema: ({ image }: SchemaContext) =>
 		z.object({
 			title: z.string(),
@@ -226,7 +238,10 @@ const articles = defineCollection({
 });
 
 const tags = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.md", base: "../../packages/shared/src/data/tags" }),
+	loader: glob({
+		pattern: "**/[^_]*.md",
+		base: "../../packages/shared/src/data/tags",
+	}),
 	schema: z.object({
 		title: z.string(),
 		slug: z.string().optional(),
@@ -234,7 +249,10 @@ const tags = defineCollection({
 });
 
 const categories = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.md", base: "../../packages/shared/src/data/categories" }),
+	loader: glob({
+		pattern: "**/[^_]*.md",
+		base: "../../packages/shared/src/data/categories",
+	}),
 	schema: z.object({
 		title: z.string(),
 		order: z.number().optional(),
@@ -242,7 +260,10 @@ const categories = defineCollection({
 });
 
 const authors = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.json", base: "../../packages/shared/src/data/authors" }),
+	loader: glob({
+		pattern: "**/[^_]*.json",
+		base: "../../packages/shared/src/data/authors",
+	}),
 	schema: z.object({
 		name: z.string(),
 		email: z.string(),

--- a/apps/blog/src/data/resume/en/resume.json
+++ b/apps/blog/src/data/resume/en/resume.json
@@ -353,7 +353,7 @@
 			"name": "Deutsche Bank",
 			"position": "Senior Software Engineer",
 			"startDate": "2023-04-08",
-      "endDate": "2025-12-18",
+			"endDate": "2025-12-18",
 			"summary": "As a Senior Software Engineer at Deutsche Bank, I bring expertise in collaborating with cross-functional teams to analyze business requirements, designing and delivering software solutions that follow best practices and high coding standards, and ensuring systems meet functional and performance goals.",
 			"url": "https://db.com"
 		},

--- a/apps/blog/src/data/resume/es/resume.json
+++ b/apps/blog/src/data/resume/es/resume.json
@@ -357,7 +357,7 @@
 			"name": "Deutsche Bank",
 			"position": "Ingeniero de Software Senior",
 			"startDate": "2023-04-08",
-      "endDate": "2025-12-18",
+			"endDate": "2025-12-18",
 			"summary": "Como Ingeniero de Software Senior en Deutsche Bank, aporto experiencia colaborando con equipos multifuncionales para analizar requisitos de negocio, diseñar y entregar soluciones de software que siguen buenas prácticas y altos estándares de codificación, asegurando que los sistemas cumplan objetivos funcionales y de rendimiento.",
 			"url": "https://db.com"
 		},

--- a/apps/blog/src/pages/[lang]/index.astro
+++ b/apps/blog/src/pages/[lang]/index.astro
@@ -1,5 +1,5 @@
 ---
-import { localeParams, type Lang } from "@/i18n";
+import { type Lang, localeParams } from "@/i18n";
 
 export function getStaticPaths() {
 	return localeParams;

--- a/apps/portfolio/playwright.config.ts
+++ b/apps/portfolio/playwright.config.ts
@@ -6,6 +6,12 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
 	testDir: "tests/e2e",
+	testIgnore: [
+		"tests/e2e/comments*.spec.ts",
+		"tests/e2e/search.spec.ts",
+		"tests/e2e/newsletter.spec.ts",
+		"tests/e2e/tag-external-articles.spec.ts",
+	],
 
 	// Test execution settings
 	timeout: 120_000, // Increased timeout for webkit stability
@@ -34,7 +40,7 @@ export default defineConfig({
 
 	// Global configuration for all tests
 	use: {
-		baseURL: process.env.BASE_URL || "http://localhost:4322",
+		baseURL: process.env.BASE_URL || "http://localhost:4321",
 		trace: "on-first-retry",
 		screenshot: "on-first-failure",
 		video: "on-first-retry",
@@ -59,8 +65,8 @@ export default defineConfig({
 				: "pnpm build";
 
 			return {
-				command: `${buildCommand} && pnpm preview --port 4322`,
-				url: "http://localhost:4322",
+				command: `${buildCommand} && pnpm preview --port 4321`,
+				url: "http://localhost:4321",
 				timeout: 600_000,
 				reuseExistingServer: false,
 				env: { PLAYWRIGHT_TEST: "true" },
@@ -70,8 +76,8 @@ export default defineConfig({
 		}
 
 		return {
-			command: "pnpm dev --port 4322",
-			url: "http://localhost:4322",
+			command: "pnpm dev --port 4321",
+			url: "http://localhost:4321",
 			timeout: 180_000,
 			reuseExistingServer: true,
 			env: { PLAYWRIGHT_TEST: "true" },

--- a/apps/portfolio/src/content.config.ts
+++ b/apps/portfolio/src/content.config.ts
@@ -23,7 +23,10 @@ const locationSchema = z.object({
 
 // System skills library collection (icons, metadata, etc.)
 const skillsLibrary = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.json", base: "../../packages/shared/src/data/skills" }),
+	loader: glob({
+		pattern: "**/[^_]*.json",
+		base: "../../packages/shared/src/data/skills",
+	}),
 	schema: z.object({
 		id: z.string(),
 		name: z.string(),
@@ -33,7 +36,10 @@ const skillsLibrary = defineCollection({
 
 // Languages library collection (language names, mappings, metadata)
 const languagesLibrary = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.json", base: "../../packages/shared/src/data/languages" }),
+	loader: glob({
+		pattern: "**/[^_]*.json",
+		base: "../../packages/shared/src/data/languages",
+	}),
 	schema: z.object({
 		code: z.string(),
 		nativeName: z.string(),
@@ -66,7 +72,10 @@ const projectMetadata = defineCollection({
 
 // Main resume collection using glob loader for multiple languages
 const resume = defineCollection({
-	loader: glob({ pattern: "**/resume.json", base: "../../packages/shared/src/data/resume" }),
+	loader: glob({
+		pattern: "**/resume.json",
+		base: "../../packages/shared/src/data/resume",
+	}),
 	schema: z.object({
 		basics: z.object({
 			name: z.string(),
@@ -209,7 +218,10 @@ const resume = defineCollection({
 });
 
 const articles = defineCollection({
-	loader: glob({ pattern: "**/*.{md,mdx}", base: "../../packages/shared/src/data/articles" }),
+	loader: glob({
+		pattern: "**/*.{md,mdx}",
+		base: "../../packages/shared/src/data/articles",
+	}),
 	schema: ({ image }: SchemaContext) =>
 		z.object({
 			title: z.string(),
@@ -226,7 +238,10 @@ const articles = defineCollection({
 });
 
 const tags = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.md", base: "../../packages/shared/src/data/tags" }),
+	loader: glob({
+		pattern: "**/[^_]*.md",
+		base: "../../packages/shared/src/data/tags",
+	}),
 	schema: z.object({
 		title: z.string(),
 		slug: z.string().optional(),
@@ -234,7 +249,10 @@ const tags = defineCollection({
 });
 
 const categories = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.md", base: "../../packages/shared/src/data/categories" }),
+	loader: glob({
+		pattern: "**/[^_]*.md",
+		base: "../../packages/shared/src/data/categories",
+	}),
 	schema: z.object({
 		title: z.string(),
 		order: z.number().optional(),
@@ -242,7 +260,10 @@ const categories = defineCollection({
 });
 
 const authors = defineCollection({
-	loader: glob({ pattern: "**/[^_]*.json", base: "../../packages/shared/src/data/authors" }),
+	loader: glob({
+		pattern: "**/[^_]*.json",
+		base: "../../packages/shared/src/data/authors",
+	}),
 	schema: z.object({
 		name: z.string(),
 		email: z.string(),

--- a/apps/portfolio/vitest.config.ts
+++ b/apps/portfolio/vitest.config.ts
@@ -6,8 +6,11 @@ import { getViteConfig } from "astro/config";
 export default getViteConfig({
 	resolve: {
 		alias: [
-			{ find: "@/", replacement: `${path.resolve("./src")}/` },
-			{ find: "@", replacement: path.resolve("./src") },
+			{
+				find: "@/",
+				replacement: `${path.resolve("../../packages/shared/src")}/`,
+			},
+			{ find: "@", replacement: path.resolve("../../packages/shared/src") },
 		],
 	},
 	// @ts-expect-error

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"test:unit:portfolio": "pnpm --filter=portfolio test:unit",
 		"test:unit:blog": "pnpm --filter=blog test:unit",
 		"test:unit:api": "pnpm --filter=yap-api test:unit",
-		"test:e2e": "pnpm --filter=portfolio --filter=blog test:e2e",
+		"test:e2e": "pnpm test:e2e:portfolio && pnpm test:e2e:blog",
 		"test:e2e:portfolio": "pnpm --filter=portfolio test:e2e",
 		"test:e2e:blog": "pnpm --filter=blog test:e2e",
 		"cloudflare:check": "bash scripts/cloudflare-check.sh",


### PR DESCRIPTION
## Summary
- align `apps/portfolio` Playwright base URL and web server ports to `4321` so it targets the correct app during E2E execution
- scope E2E suites per app using `testIgnore` (`portfolio` ignores blog-only specs, `blog` ignores portfolio contact-form spec)
- run root `test:e2e` sequentially (`portfolio` then `blog`) to avoid cross-app test server contention in monorepo runs

## Validation
- `pnpm test:e2e`
- `make preflight`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Exclude specific end-to-end tests from automated runs.
  * Change development/preview server port and base URL to use port 4321.
  * Update e2e script to run portfolio and blog tests sequentially.

* **Refactor**
  * Adjust test tooling alias resolution to reference the shared package source.

* **Style**
  * Reformat imports, config objects, and JSON whitespace for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->