### PR TITLE
Update documentation for monorepo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# Welcome to my personal portfolio made with [Astro](https://astro.build)
+# Welcome to my personal monorepo portfolio made with [Astro](https://astro.build)
 
-![Deploy Reliability](https://img.shields.io/github/actions/workflow/status/yacosta738/yacosta738.github.io/deploy.yml?label=deploy%20reliability)
-[![CI](https://github.com/yacosta738/yacosta738.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/yacosta738/yacosta738.github.io/actions/workflows/ci.yml)
+![Deploy Portfolio](https://img.shields.io/github/actions/workflow/status/yacosta738/yacosta738.github.io/deploy-portfolio.yml?label=deploy%20portfolio)
+![Deploy API](https://img.shields.io/github/actions/workflow/status/yacosta738/yacosta738.github.io/deploy-api.yml?label=deploy%20api)
+[![CI Pipeline](https://github.com/yacosta738/yacosta738.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/yacosta738/yacosta738.github.io/actions/workflows/ci.yml)
 ![CI Reliability](https://img.shields.io/github/actions/workflow/status/yacosta738/yacosta738.github.io/ci.yml?label=ci%20reliability)
 [![Playwright E2E Tests](https://github.com/yacosta738/yacosta738.github.io/actions/workflows/playwright.yml/badge.svg)](https://github.com/yacosta738/yacosta738.github.io/actions/workflows/playwright.yml)
 ![E2E Reliability](https://img.shields.io/github/actions/workflow/status/yacosta738/yacosta738.github.io/playwright.yml?label=e2e%20reliability)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/0c5e5ad4-8565-4a37-b181-b4442505a68b/deploy-status)](https://app.netlify.com/sites/yunielacosta/deploys)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=yacosta738_yacosta738.github.io&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=yacosta738_yacosta738.github.io)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=yacosta738_yacosta738.github.io&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=yacosta738_yacosta738.github.io)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=yacosta738_yacosta738.github.io&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=yacosta738_yacosta738.github.io)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=yacosta738_yacosta738.github.io&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=yacosta738_yacosta738.github.io)
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=yacosta738_yacosta738.github.io&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=yacosta738_yacosta738.github.io)
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=yacosta738_yacosta738.github.io&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=yacosta738_yacosta738.github.io)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=yacosta738_yacosta738.github.io&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=yacosta738_yacosta738.github.io)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=yacosta738_yacosta738.github.io&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=yacosta738_yacosta738.github.io)
@@ -43,80 +42,46 @@ Thank you for taking the time to visit my portfolio. Feel free to explore and ge
 
 ## 🚀 Project Structure
 
-Inside of your Astro project, you'll see the following folders and files:
+This is a monorepo managed with pnpm workspaces. It contains multiple applications and shared packages.
 
 ```shell
-drwxr-xr-x     - yap 25 Dec 10:43 .
-.rw-r--r--  1.4k yap 23 Dec 09:28 ├── astro.config.ts
-.rw-r--r--   374 yap  5 Nov 14:11 ├── Dockerfile
-drwxr-xr-x     - yap 25 Dec 10:41 ├── docs
-drwxr-xr-x     - yap 25 Dec 10:41 │  └── images
-.rw-r--r--    32 yap  5 Nov 14:11 ├── netlify.toml
-.rw-r--r--  2.8k yap 23 Dec 16:15 ├── package.json
-.rw-r--r--@ 2.6k yap 18 Dec 20:15 ├── playwright.config.ts
-.rw-r--r--  518k yap 25 Dec 10:09 ├── pnpm-lock.yaml
-drwxr-xr-x     - yap 18 Dec 20:15 ├── public
-.rw-r--r--   13k yap  5 Nov 14:11 │  ├── android-chrome-192x192.png
-.rw-r--r--   47k yap  5 Nov 14:11 │  ├── android-chrome-512x512.png
-.rw-r--r--   12k yap  5 Nov 14:11 │  ├── apple-touch-icon.png
-.rw-r--r--   336 yap  5 Nov 14:11 │  ├── browserconfig.xml
-.rw-r--r--   559 yap  5 Nov 14:11 │  ├── favicon-16x16.png
-.rw-r--r--  1.5k yap  5 Nov 14:11 │  ├── favicon-32x32.png
-.rw-r--r--  9.3k yap  5 Nov 14:11 │  ├── favicon.ico
-drwxr-xr-x     - yap  5 Nov 14:11 │  ├── files
-drwxr-xr-x     - yap  5 Nov 14:11 │  ├── fonts
-.rw-r--r--@  253 yap  5 Nov 14:11 │  ├── humans.txt
-.rw-r--r--   12k yap  5 Nov 14:11 │  ├── logo.svg
-.rw-r--r--   20k yap  5 Nov 14:11 │  ├── oops.webp
-drwxr-xr-x     - yap  5 Nov 14:11 │  ├── rss
-drwxr-xr-x     - yap  5 Nov 14:11 │  ├── images
-.rw-r--r--   19k yap  5 Nov 14:11 │  └── you-are-the-best.webp
-.rw-r--r--@ 7.8k yap 25 Dec 10:43 ├── README.md
-.rw-r--r--@  508 yap 18 Dec 20:15 ├── remark-reading-time.mjs
-.rw-r--r--@  541 yap 18 Dec 20:15 ├── renovate.json
-.rw-r--r--   619 yap  5 Nov 14:11 ├── SECURITY.md
-drwxr-xr-x     - yap 20 Dec 15:36 ├── src
-drwxr-xr-x     - yap 20 Dec 15:36 │  ├── assets
-drwxr-xr-x     - yap  5 Nov 14:11 │  ├── components
-drwxr-xr-x@    - yap 18 Dec 20:15 │  ├── content
-.rw-r--r--@  453 yap 22 Dec 17:05 │  ├── env.d.ts
-drwxr-xr-x@    - yap 23 Dec 16:17 │  ├── i18n
-drwxr-xr-x     - yap  5 Nov 14:11 │  ├── icons
-drwxr-xr-x     - yap 18 Dec 20:15 │  ├── models
-drwxr-xr-x     - yap 18 Dec 20:15 │  ├── pages
-drwxr-xr-x     - yap 18 Dec 20:15 │  ├── plugins
-drwxr-xr-x     - yap 18 Dec 20:15 │  ├── store
-drwxr-xr-x     - yap 24 Dec 12:08 │  ├── styles
-drwxr-xr-x     - yap 18 Dec 20:15 │  └── utils
-.rw-r--r--@ 2.4k yap 18 Dec 20:15 ├── tailwind.config.cjs
-drwxr-xr-x     - yap  5 Nov 14:11 ├── tests
-drwxr-xr-x     - yap 24 Dec 16:35 │  ├── integration
-drwxr-xr-x     - yap 18 Dec 20:15 │  └── unit
-.rw-r--r--@ 1.2k yap 21 Dec 17:08 ├── tsconfig.json
-.rw-r--r--@  252 yap 18 Dec 20:15 └── vitest.config.ts
+.
+├── apps/
+│   ├── portfolio/      # Main portfolio website (Astro)
+│   ├── blog/           # Personal blog (Astro)
+│   └── api/            # Backend API (Cloudflare Workers + Hono)
+├── packages/
+│   └── shared/         # Shared logic, components, and types
+├── docs/               # Project documentation
+├── scripts/            # Helper scripts
+├── specs/              # Project specifications
+└── package.json        # Root package.json
 ```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components or layouts.
-
-Any static assets, like images, can be placed in the `public/` directory.
 
 ## 🧞 Commands
 
-All commands are run from the root of the project, from a terminal:
+All commands are run from the root of the project using pnpm:
 
-| Command                   | Action                                             |
-| :------------------------ | :------------------------------------------------- |
-| `npm install`             | Installs dependencies                              |
-| `npm run dev`             | Starts local dev server at `localhost:4321`        |
-| `npm run build`           | Build your production site to `./dist/`            |
-| `npm run preview`         | Preview your build locally, before deploying       |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro preview` |
-| `npm run astro --help`    | Get help using the Astro CLI                       |
-| `npm run format`          | Format your code with Prettier                     |
-| `npm run lint`             | Lint your code with Biome                         |
-| `npm run test`            | Run your tests with Playwright                     |
-| `npm run test:e2e`        | Run your end-to-end tests with Playwright          |
+### Global Commands
+
+| Command | Action |
+| :--- | :--- |
+| `pnpm install` | Installs dependencies for all projects |
+| `pnpm run dev` | Starts all applications in development mode |
+| `pnpm run build` | Builds all applications |
+| `pnpm run test` | Runs all unit and E2E tests |
+| `pnpm run lint` | Lints the entire codebase with Biome |
+| `pnpm run check` | Runs type checks and linting for all apps |
+
+### App-Specific Commands
+
+| App | Command | Action |
+| :--- | :--- | :--- |
+| **Portfolio** | `pnpm dev:portfolio` | Dev server for portfolio |
+| | `pnpm build:portfolio` | Build portfolio |
+| **Blog** | `pnpm dev:blog` | Dev server for blog |
+| | `pnpm build:blog` | Build blog |
+| **API** | `pnpm dev:api` | Dev server for API |
+| | `pnpm build:api` | Build API |
 
 ![Alt](https://repobeats.axiom.co/api/embed/e814d9379628a6c98c24408834f6394ec8ea0c07.svg "Repobeats analytics image")

--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -1,0 +1,34 @@
+# Blog Application
+
+A personal blog application built with [Astro](https://astro.build/). It shares thoughts on software development, productivity, and technology.
+
+## 🚀 Features
+
+- **Astro 5**: Optimized for content-heavy sites.
+- **MDX Support**: Write articles using Markdown and components.
+- **Search**: Integrated search functionality.
+- **RSS Feed**: Automatically generated RSS feeds for multiple languages.
+- **SEO Optimized**: Meta tags, sitemaps, and open graph images.
+
+## 🧞 Commands
+
+All commands are run from the root of the monorepo or from this directory:
+
+| Command | Action |
+| :--- | :--- |
+| `pnpm dev` | Starts local dev server |
+| `pnpm build` | Build the production site |
+| `pnpm preview` | Preview the build locally |
+| `pnpm check` | Run type checks and linting |
+| `pnpm test:unit` | Run unit tests with Vitest |
+| `pnpm test:e2e` | Run end-to-end tests with Playwright |
+
+## 📁 Structure
+
+- `src/content/`: Articles and external links.
+- `src/pages/`: Blog routes and RSS generation.
+- `scripts/`: Helper scripts for organizing articles and updating CSP.
+
+## 📄 License
+
+See the root `README.md` for license information.

--- a/apps/portfolio/README.md
+++ b/apps/portfolio/README.md
@@ -1,0 +1,37 @@
+# Portfolio Application
+
+This is the main portfolio application, built with [Astro](https://astro.build/). It showcases projects, experience, and skills.
+
+## 🚀 Features
+
+- **Astro 5**: High-performance static site generation.
+- **Tailwind CSS 4**: Modern styling with the latest Tailwind features.
+- **i18n**: Full internationalization support (English, Spanish, French).
+- **View Transitions**: Smooth page transitions using Astro's native API.
+- **Contact Form**: Integrated with a secure backend API.
+- **Unit & E2E Testing**: Comprehensive testing suite with Vitest and Playwright.
+
+## 🧞 Commands
+
+All commands are run from the root of the monorepo or from this directory:
+
+| Command | Action |
+| :--- | :--- |
+| `pnpm dev` | Starts local dev server at `localhost:4321` |
+| `pnpm build` | Build the production site to `./dist/` |
+| `pnpm preview` | Preview the build locally |
+| `pnpm check` | Run type checks and linting |
+| `pnpm test:unit` | Run unit tests with Vitest |
+| `pnpm test:e2e` | Run end-to-end tests with Playwright |
+
+## 📁 Structure
+
+- `src/components/`: Astro and React components.
+- `src/content/`: Content collections for articles and projects.
+- `src/layouts/`: Page layouts.
+- `src/pages/`: Application routes.
+- `src/i18n/`: Internationalization logic and translations.
+
+## 📄 License
+
+See the root `README.md` for license information.

--- a/docs/getting-started/api-guide.md
+++ b/docs/getting-started/api-guide.md
@@ -34,7 +34,7 @@ Component (e.g., Contact.astro)
 
 ## 2. Service Layer Implementation
 
-A new service layer was created at `apps/portfolio/src/services/` to handle all API communication.
+A new service layer was created at `packages/shared/src/services/` to handle all API communication.
 
 ### File Structure
 ```text
@@ -165,8 +165,8 @@ The worker exposes the following endpoints.
 - **Documentation (5 files):** The original set of migration documents.
 
 ### Files Modified
-- `apps/portfolio/src/components/sections/Contact.astro`: Updated to use `contactService`.
-- `apps/portfolio/src/components/organisms/CtaNewsletterSubscription.astro`: Updated to use `newsletterService`.
+- `packages/shared/src/components/sections/Contact.astro`: Updated to use `contactService`.
+- `packages/shared/src/components/organisms/CtaNewsletterSubscription.astro`: Updated to use `newsletterService`.
 - `.env.example`: Added `API_URL`.
 
 ### Files to Delete

--- a/docs/getting-started/portfolio-guide.md
+++ b/docs/getting-started/portfolio-guide.md
@@ -1,74 +1,59 @@
 # Portfolio Application Guide
 
-This document provides a comprehensive overview of the `portfolio` application, covering its architecture, tech stack, and key features.
+This document provides an overview of the `portfolio` application within the monorepo.
 
 ## 1. Overview
 
-The portfolio is a modern, content-driven static site built with [Astro](https://astro.build/). It is designed to be highly performant by shipping zero JavaScript by default, while also being easily deployable to various platforms thanks to a dynamic adapter system.
+The portfolio is a modern, content-driven static site built with [Astro](https://astro.build/). As part of our monorepo transition, the portfolio app has been streamlined to focus on routing and page configuration, while leveraging shared components and logic from the `shared` package.
 
 ## 2. Tech Stack
 
--   **Framework**: [Astro](https://astro.build/) for templating and page generation.
--   **Styling**: [Tailwind CSS](https://tailwindcss.com/) for utility-first styling, with minimal custom CSS.
--   **Content**: [Astro Content Collections](https://docs.astro.build/en/guides/content-collections/) for type-safe Markdown and JSON data management.
--   **Testing**:
-    -   [Playwright](https://playwright.dev/) for End-to-End (E2E) testing.
-    -   [Vitest](https://vitest.dev/) for unit and component testing.
+- **Framework**: [Astro 5](https://astro.build/) using the new Content Layer API.
+- **Styling**: [Tailwind CSS 4](https://tailwindcss.com/) via the `shared` package.
+- **Content**: [Astro Content Collections](https://docs.astro.build/en/guides/content-collections/) powered by the `glob` loader pointing to shared data.
+- **Testing**:
+    - [Playwright](https://playwright.dev/) for E2E testing.
+    - [Vitest](https://vitest.dev/) for unit testing.
 
-## 3. Architecture
+## 3. Architecture (Monorepo)
 
-The project follows the principles of **Clean Architecture** and **Atomic Design** to ensure a strong separation of concerns and a scalable component library.
+The portfolio follows a "thin app" pattern where UI components and business logic are imported from `@packages/shared`.
 
-### Architectural Layers
+### Key Locations
 
-1.  **Data Layer (Entities)**
-    -   **Location**: `src/data/**/*.json` and `src/content/`
-    -   **Description**: This is the core of the application, containing all raw data for the resume, blog posts, and projects. The shape of this data is strictly defined by TypeScript interfaces in `src/lib/resume-types.ts` and validated by Zod schemas in `src/content/config.ts`.
-
-2.  **Business Logic (Use Cases)**
-    -   **Location**: `src/lib/`, `src/core/`, and `src/services/`
-    -   **Description**: This layer contains the logic to process, parse, and prepare data for the UI. It also includes the service layer (`src/services/`) responsible for communicating with the external API worker for features like the contact and newsletter forms.
-
-3.  **Presentation Layer (UI)**
-    -   **Location**: `src/components/`, `src/layouts/`, `src/pages/`
-    -   **Description**: This layer is responsible for rendering the UI. It is organized using Atomic Design principles:
-        -   **Atoms (`src/components/atoms/`)**: The smallest, indivisible UI elements (e.g., buttons, section wrappers).
-        -   **Organisms (`src/components/organisms/`)**: More complex components that correspond to full sections of the site (e.g., the Experience section), composed of multiple atoms.
-        -   **Layouts (`src/layouts/`)**: The overall page structure, arranging organisms into a cohesive whole.
-        -   **Pages (`src/pages/`)**: The final pages that fetch data and pass it down to the appropriate layout and components.
+1. **Pages & Routing**: `apps/portfolio/src/pages/`
+   - Handles the actual URL structure and page-level data fetching.
+2. **Content Configuration**: `apps/portfolio/src/content.config.ts`
+   - Uses the `glob` loader to pull content from `../../packages/shared/src/data/`.
+3. **Shared Resources**:
+   - **Components**: Imported from `@packages/shared/components/`.
+   - **Layouts**: Imported from `@packages/shared/layouts/`.
+   - **Logic**: Imported from `@packages/shared/lib/` and `@packages/shared/services/`.
 
 ## 4. Content Management
 
-All content is managed through Astro Content Collections, configured in `src/content/config.ts`. This provides:
--   **Type Safety**: Ensures that all Markdown frontmatter and JSON data adhere to a defined schema.
--   **Data Validation**: Automatically validates content at build time, preventing errors.
--   **Easy Querying**: Provides a simple API for fetching and filtering content within Astro pages.
+All content is managed centrally in `packages/shared/src/data/`. This includes:
+- **Resume**: Professional experience, education, and skills.
+- **Articles**: Markdown and MDX files for the blog.
+- **Projects**: Metadata for showcased projects.
+
+The `portfolio` app uses its own `content.config.ts` to define how it consumes this shared data, providing type safety and validation at build time.
 
 ## 5. Styling
 
--   **Tailwind CSS** is the primary method for styling. Utility classes are preferred over custom CSS.
--   **Global Styles**: Minimal global styles are located in `src/styles/global.css`.
--   **Component Styles**: When custom CSS is necessary, it is scoped directly within Astro components using `<style>` blocks.
+Styling is centralized in `packages/shared/src/styles/`. The portfolio app imports the global CSS and uses Tailwind CSS 4 for utility classes.
 
-## 6. Key Features
+## 6. How to Run Locally
 
--   **Internationalization (i18n)**: The site supports multiple languages (English and Spanish). The logic in `src/i18n/` handles language detection and path generation. A custom solution detailed in `docs/guides/i18n-tags.md` provides smart fallbacks for tag pages.
--   **API Integration**: The portfolio communicates with a separate Cloudflare Worker for handling form submissions. This is managed by a dedicated, testable service layer in `src/services/`, ensuring the frontend is decoupled from the API backend.
--   **Dynamic Deployment**: The application can be deployed to multiple platforms (Node.js, Vercel, Cloudflare) by setting the `DEPLOYMENT_ADAPTER` environment variable. This is configured in `astro.config.mjs` and documented in `docs/guides/deployment.md`.
+From the root of the monorepo:
 
-## 7. How to Run Locally
-
-1.  Navigate to the portfolio directory:
-    ```bash
-    cd apps/portfolio
-    ```
-2.  Install dependencies:
-    ```bash
-    pnpm install
-    ```
-3.  Start the development server:
-    ```bash
-    pnpm dev
-    ```
+1. **Start Development**:
+   ```bash
+   pnpm dev:portfolio
+   ```
+2. **Build for Production**:
+   ```bash
+   pnpm build:portfolio
+   ```
 
 The application will be available at `http://localhost:4321`.

--- a/docs/guides/hcaptcha-astro-fix.md
+++ b/docs/guides/hcaptcha-astro-fix.md
@@ -104,7 +104,7 @@ declare global {
 
 ## Archivos Modificados
 
-### 1. `/apps/portfolio/src/components/atoms/HCaptcha.astro`
+### 1. `/packages/shared/src/components/atoms/HCaptcha.astro`
 - **Cambio principal**: Implementación completa de renderizado explícito
 - **Mejoras**:
   - Renderizado manual con `hcaptcha.render()`
@@ -113,11 +113,11 @@ declare global {
   - Prevención de layout shift con `min-height`
   - Mejor manejo de errores y timeouts
 
-### 2. `/apps/portfolio/src/components/organisms/CtaNewsletterSubscription.astro`
+### 2. `/packages/shared/src/components/organisms/CtaNewsletterSubscription.astro`
 - **Cambio**: Removidas declaraciones de tipos duplicadas
 - **Motivo**: Los tipos ahora están centralizados en `hcaptcha.d.ts`
 
-### 3. `/apps/portfolio/src/components/sections/Contact.astro`
+### 3. `/packages/shared/src/components/sections/Contact.astro`
 - **Cambio**: Removidas declaraciones de tipos duplicadas
 - **Motivo**: Los tipos ahora están centralizados en `hcaptcha.d.ts`
 

--- a/docs/guides/security-hcaptcha.md
+++ b/docs/guides/security-hcaptcha.md
@@ -106,7 +106,7 @@ echo "HCAPTCHA_SECRET_KEY=YOUR_SECRET_KEY_HERE" >> .dev.vars
 
 ### Frontend Components
 
-- **`HCaptcha.astro`**: A reusable component at `apps/portfolio/src/components/atoms/HCaptcha.astro` that handles loading the hCaptcha script and rendering the widget.
+- **`HCaptcha.astro`**: A reusable component at `packages/shared/src/components/atoms/HCaptcha.astro` that handles loading the hCaptcha script and rendering the widget.
 - **Form Integrations**: The widget is integrated into the contact form (`Contact.astro`) and the newsletter form (`CtaNewsletterSubscription.astro`). Client-side scripts in these components ensure a token is present before allowing a form to be submitted.
 
 ### Backend Verification

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,53 @@
+# Shared Package
+
+This package contains shared logic, components, and data used by the applications in this monorepo (`portfolio` and `blog`).
+
+## 📦 Contents
+
+- **Data**: Centralized content for articles, authors, projects, and skills.
+- **i18n**: Core internationalization logic, translations, and reusable components.
+- **Services**: API client and service abstractions for backend communication.
+- **Library**: Utility functions and common types.
+- **Icons**: Shared SVG icons.
+
+## 📁 Structure
+
+```
+src/
+├── data/          # JSON and MD/MDX data files
+├── i18n/          # Shared translations and logic
+├── icons/         # Shared SVG assets
+├── layouts/       # Reusable Astro layouts
+├── lib/           # Common utilities
+├── services/      # API communication layer
+├── styles/        # Global CSS and fonts
+└── types/         # Common TypeScript definitions
+```
+
+## 🚀 Usage
+
+This package is intended to be used as a dependency in the other apps in the monorepo. It is not a standalone application.
+
+Example of using a shared service:
+
+```typescript
+import { contactService } from "@packages/shared/services";
+```
+
+Example of using shared translations:
+
+```typescript
+import { useTranslations } from "@packages/shared/i18n";
+```
+
+## 🧪 Testing
+
+Unit tests for shared logic are located in `src/lib` and other directories. Run them using:
+
+```bash
+pnpm test:unit
+```
+
+## 📄 License
+
+See the root `README.md` for license information.


### PR DESCRIPTION
This PR updates the project's documentation to accurately reflect its transition to a monorepo structure using pnpm workspaces. It fixes broken CI/CD badges, updates the root README with a new directory tree and workspace commands, adds missing READMEs to sub-projects, and audits internal documentation links to ensure they point to the new locations of shared resources in `packages/shared`.

---
*PR created automatically by Jules for task [5206558950314895971](https://jules.google.com/task/5206558950314895971) started by @yacosta738*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README files to reflect new monorepo organization with pnpm-based commands
  * Added comprehensive documentation for Blog and Portfolio applications with features and available commands
  * Reorganized getting-started guides to align with updated monorepo architecture
  * Enhanced HCaptcha integration documentation with TypeScript type support

* **New Features**
  * Introduced TypeScript type definitions for HCaptcha API interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->