### PR TITLE
fix: improve canonical and alternate URL handling for SEO and localhost environments

### DIFF
--- a/apps/blog/src/pages/404.astro
+++ b/apps/blog/src/pages/404.astro
@@ -5,15 +5,16 @@
 import { DEFAULT_LOCALE, LOCALES } from "@/i18n";
 
 const langs = Object.keys(LOCALES);
-const baseUrl = import.meta.env.PROD ? Astro.site : "/";
+const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
+const canonicalHref = "/";
 ---
 
 <html lang={DEFAULT_LOCALE}>
   <head>
     <meta charset="UTF-8" />
     <title>404 PAGE NOT FOUND</title>
-    <link rel="canonical" href={Astro.site} />
+    <link rel="canonical" href={canonicalHref} />
 
     <noscript>
       <meta

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -15,17 +15,16 @@ import {
 	LOCALES,
 	useTranslations,
 } from "@/i18n";
-import { getPublicOrigin } from "@/utils/public-origin";
+import { getOriginAndOg } from "@/utils/public-origin";
 
 const t = useTranslations(Astro.currentLocale as Lang);
 const langs = Object.keys(LOCALES);
 const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
-const alternatesOrigin = getPublicOrigin(Astro.site);
-const fallbackOrigin = "http://localhost";
-const alternatesOriginWithFallback = alternatesOrigin || fallbackOrigin;
-const ogImage = `${alternatesOriginWithFallback}/ogp.png`;
-const ogUrl = `${alternatesOriginWithFallback}/${defaultLocale}/`;
+const { alternatesOrigin, ogImage, ogUrl } = getOriginAndOg(
+	Astro.site,
+	defaultLocale,
+);
 ---
 
 <html lang={DEFAULT_LOCALE}>

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -18,8 +18,16 @@ import {
 
 const t = useTranslations(Astro.currentLocale as Lang);
 const langs = Object.keys(LOCALES);
-const baseUrl = import.meta.env.PROD ? Astro.site : "/";
+const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
+const alternatesOrigin =
+	Astro.site &&
+	Astro.site.hostname !== "localhost" &&
+	Astro.site.hostname !== "127.0.0.1"
+		? Astro.site.origin
+		: "";
+const ogImage = `${alternatesOrigin}/ogp.png`;
+const ogUrl = `${alternatesOrigin}/${defaultLocale}/`;
 ---
 
 <html lang={DEFAULT_LOCALE}>
@@ -33,7 +41,7 @@ const defaultLocale = DEFAULT_LOCALE;
         <link
             rel="alternate"
             hreflang={LOCALES[props.lang].lang || props.lang}
-            href={Astro.site?.origin + props.path}
+            href={`${alternatesOrigin}${props.path}`}
         />
     ))
   }
@@ -49,8 +57,8 @@ const defaultLocale = DEFAULT_LOCALE;
   <meta property="og:title" content={t(SITE_TITLE)} />
   <meta property="og:site_name" content={t(SITE_TITLE)} />
   <meta property="og:description" content={t(SITE_DESCRIPTION)} />
-  <meta property="og:image" content={Astro.site + "ogp.png"} />
-  <meta property="og:url" content={Astro.url} />
+  <meta property="og:image" content={ogImage} />
+  <meta property="og:url" content={ogUrl} />
   <meta property="og:locale" content={DEFAULT_LOCALE} />
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content={t(X_ACCOUNT)} />

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -15,17 +15,13 @@ import {
 	LOCALES,
 	useTranslations,
 } from "@/i18n";
+import { getPublicOrigin } from "@/utils/public-origin";
 
 const t = useTranslations(Astro.currentLocale as Lang);
 const langs = Object.keys(LOCALES);
 const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
-const alternatesOrigin =
-	Astro.site &&
-	Astro.site.hostname !== "localhost" &&
-	Astro.site.hostname !== "127.0.0.1"
-		? Astro.site.origin
-		: "";
+const alternatesOrigin = getPublicOrigin(Astro.site);
 const ogImage = `${alternatesOrigin}/ogp.png`;
 const ogUrl = `${alternatesOrigin}/${defaultLocale}/`;
 ---

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -22,8 +22,10 @@ const langs = Object.keys(LOCALES);
 const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
 const alternatesOrigin = getPublicOrigin(Astro.site);
-const ogImage = `${alternatesOrigin}/ogp.png`;
-const ogUrl = `${alternatesOrigin}/${defaultLocale}/`;
+const fallbackOrigin = "http://localhost";
+const alternatesOriginWithFallback = alternatesOrigin || fallbackOrigin;
+const ogImage = `${alternatesOriginWithFallback}/ogp.png`;
+const ogUrl = `${alternatesOriginWithFallback}/${defaultLocale}/`;
 ---
 
 <html lang={DEFAULT_LOCALE}>

--- a/apps/portfolio/src/pages/404.astro
+++ b/apps/portfolio/src/pages/404.astro
@@ -5,15 +5,16 @@
 import { DEFAULT_LOCALE, LOCALES } from "@/i18n";
 
 const langs = Object.keys(LOCALES);
-const baseUrl = import.meta.env.PROD ? Astro.site : "/";
+const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
+const canonicalHref = "/";
 ---
 
 <html lang={DEFAULT_LOCALE}>
   <head>
     <meta charset="UTF-8" />
     <title>404 PAGE NOT FOUND</title>
-    <link rel="canonical" href={Astro.site} />
+    <link rel="canonical" href={canonicalHref} />
 
     <noscript>
       <meta

--- a/apps/portfolio/src/pages/index.astro
+++ b/apps/portfolio/src/pages/index.astro
@@ -15,17 +15,16 @@ import {
 	LOCALES,
 	useTranslations,
 } from "@/i18n";
-import { getPublicOrigin } from "@/utils/public-origin";
+import { getOriginAndOg } from "@/utils/public-origin";
 
 const t = useTranslations(Astro.currentLocale as Lang);
 const langs = Object.keys(LOCALES);
 const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
-const alternatesOrigin = getPublicOrigin(Astro.site);
-const fallbackOrigin = "http://localhost";
-const alternatesOriginWithFallback = alternatesOrigin || fallbackOrigin;
-const ogImage = `${alternatesOriginWithFallback}/ogp.png`;
-const ogUrl = `${alternatesOriginWithFallback}/${defaultLocale}/`;
+const { alternatesOrigin, ogImage, ogUrl } = getOriginAndOg(
+	Astro.site,
+	defaultLocale,
+);
 ---
 
 <html lang={DEFAULT_LOCALE}>

--- a/apps/portfolio/src/pages/index.astro
+++ b/apps/portfolio/src/pages/index.astro
@@ -18,8 +18,16 @@ import {
 
 const t = useTranslations(Astro.currentLocale as Lang);
 const langs = Object.keys(LOCALES);
-const baseUrl = import.meta.env.PROD ? Astro.site : "/";
+const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
+const alternatesOrigin =
+	Astro.site &&
+	Astro.site.hostname !== "localhost" &&
+	Astro.site.hostname !== "127.0.0.1"
+		? Astro.site.origin
+		: "";
+const ogImage = `${alternatesOrigin}/ogp.png`;
+const ogUrl = `${alternatesOrigin}/${defaultLocale}/`;
 ---
 
 <html lang={DEFAULT_LOCALE}>
@@ -33,7 +41,7 @@ const defaultLocale = DEFAULT_LOCALE;
         <link
             rel="alternate"
             hreflang={LOCALES[props.lang].lang || props.lang}
-            href={Astro.site?.origin + props.path}
+            href={`${alternatesOrigin}${props.path}`}
         />
     ))
   }
@@ -49,8 +57,8 @@ const defaultLocale = DEFAULT_LOCALE;
   <meta property="og:title" content={t(SITE_TITLE)} />
   <meta property="og:site_name" content={t(SITE_TITLE)} />
   <meta property="og:description" content={t(SITE_DESCRIPTION)} />
-  <meta property="og:image" content={Astro.site + "ogp.png"} />
-  <meta property="og:url" content={Astro.url} />
+  <meta property="og:image" content={ogImage} />
+  <meta property="og:url" content={ogUrl} />
   <meta property="og:locale" content={DEFAULT_LOCALE} />
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content={t(X_ACCOUNT)} />

--- a/apps/portfolio/src/pages/index.astro
+++ b/apps/portfolio/src/pages/index.astro
@@ -15,17 +15,13 @@ import {
 	LOCALES,
 	useTranslations,
 } from "@/i18n";
+import { getPublicOrigin } from "@/utils/public-origin";
 
 const t = useTranslations(Astro.currentLocale as Lang);
 const langs = Object.keys(LOCALES);
 const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
-const alternatesOrigin =
-	Astro.site &&
-	Astro.site.hostname !== "localhost" &&
-	Astro.site.hostname !== "127.0.0.1"
-		? Astro.site.origin
-		: "";
+const alternatesOrigin = getPublicOrigin(Astro.site);
 const ogImage = `${alternatesOrigin}/ogp.png`;
 const ogUrl = `${alternatesOrigin}/${defaultLocale}/`;
 ---

--- a/apps/portfolio/src/pages/index.astro
+++ b/apps/portfolio/src/pages/index.astro
@@ -22,8 +22,10 @@ const langs = Object.keys(LOCALES);
 const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
 const alternatesOrigin = getPublicOrigin(Astro.site);
-const ogImage = `${alternatesOrigin}/ogp.png`;
-const ogUrl = `${alternatesOrigin}/${defaultLocale}/`;
+const fallbackOrigin = "http://localhost";
+const alternatesOriginWithFallback = alternatesOrigin || fallbackOrigin;
+const ogImage = `${alternatesOriginWithFallback}/ogp.png`;
+const ogUrl = `${alternatesOriginWithFallback}/${defaultLocale}/`;
 ---
 
 <html lang={DEFAULT_LOCALE}>

--- a/packages/shared/src/components/atoms/ObfuscateEmail.astro
+++ b/packages/shared/src/components/atoms/ObfuscateEmail.astro
@@ -125,5 +125,7 @@ const obfuscatedEmail = email
             });
         }
     }
-    customElements.define("obfuscate-email", ObfuscateEmail);
+    if (!customElements.get("obfuscate-email")) {
+        customElements.define("obfuscate-email", ObfuscateEmail);
+    }
 </script>

--- a/packages/shared/src/components/molecules/Email.astro
+++ b/packages/shared/src/components/molecules/Email.astro
@@ -135,6 +135,7 @@ const obfuscatedEmail = email
             });
         }
     }
-    customElements.define("obfuscate-side-email", ObfuscateSideEmail);
+    if (!customElements.get("obfuscate-side-email")) {
+        customElements.define("obfuscate-side-email", ObfuscateSideEmail);
+    }
 </script>
-

--- a/packages/shared/src/components/sections/Experience.astro
+++ b/packages/shared/src/components/sections/Experience.astro
@@ -28,6 +28,49 @@ interface GroupedCompany {
 	positions: Work[];
 }
 
+const isCurrentPosition = (position: Work): boolean => {
+	return position.endDate === null || position.endDate === undefined;
+};
+
+const sortPositionsByRecency = (a: Work, b: Work): number => {
+	const aIsCurrent = isCurrentPosition(a);
+	const bIsCurrent = isCurrentPosition(b);
+
+	if (aIsCurrent !== bIsCurrent) {
+		return aIsCurrent ? -1 : 1;
+	}
+
+	return b.startDate.getTime() - a.startDate.getTime();
+};
+
+const getCompanySortKey = (
+	group: GroupedCompany,
+): { hasCurrentRole: boolean; latestRelevantDate: number } => {
+	const currentRoles = group.positions.filter(isCurrentPosition);
+
+	if (currentRoles.length > 0) {
+		const latestCurrentStartDate = Math.max(
+			...currentRoles.map((position) => position.startDate.getTime()),
+		);
+
+		return {
+			hasCurrentRole: true,
+			latestRelevantDate: latestCurrentStartDate,
+		};
+	}
+
+	const latestClosedDate = Math.max(
+		...group.positions.map((position) => {
+			return position.endDate?.getTime() ?? position.startDate.getTime();
+		}),
+	);
+
+	return {
+		hasCurrentRole: false,
+		latestRelevantDate: latestClosedDate,
+	};
+};
+
 const { work } = Astro.props as Props;
 const currentLocale = Astro.params.lang as Lang;
 const t = useTranslations(currentLocale);
@@ -50,19 +93,22 @@ const groupedWork: Record<string, GroupedCompany> = work.reduce(
 	{} as Record<string, GroupedCompany>,
 );
 
-// Sort positions within each company by start date (most recent first)
+// Sort positions within each company: open roles first, then by recency.
 Object.values(groupedWork).forEach((group: GroupedCompany) => {
-	group.positions.sort(
-		(a: Work, b: Work) => b.startDate.getTime() - a.startDate.getTime(),
-	);
+	group.positions.sort(sortPositionsByRecency);
 });
 
-// Convert to array and sort by most recent position start date
+// Sort companies: open roles first, then most recent activity.
 const sortedCompanies: GroupedCompany[] = Object.values(groupedWork).sort(
 	(a: GroupedCompany, b: GroupedCompany) => {
-		const aLatest = a.positions[0].startDate.getTime();
-		const bLatest = b.positions[0].startDate.getTime();
-		return bLatest - aLatest;
+		const aSortKey = getCompanySortKey(a);
+		const bSortKey = getCompanySortKey(b);
+
+		if (aSortKey.hasCurrentRole !== bSortKey.hasCurrentRole) {
+			return aSortKey.hasCurrentRole ? -1 : 1;
+		}
+
+		return bSortKey.latestRelevantDate - aSortKey.latestRelevantDate;
 	},
 );
 ---

--- a/packages/shared/src/components/sections/Experience.astro
+++ b/packages/shared/src/components/sections/Experience.astro
@@ -40,7 +40,10 @@ const sortPositionsByRecency = (a: Work, b: Work): number => {
 		return aIsCurrent ? -1 : 1;
 	}
 
-	return b.startDate.getTime() - a.startDate.getTime();
+	const aActivity = (a.endDate ?? a.startDate).getTime();
+	const bActivity = (b.endDate ?? b.startDate).getTime();
+
+	return bActivity - aActivity;
 };
 
 const getCompanySortKey = (
@@ -99,18 +102,22 @@ Object.values(groupedWork).forEach((group: GroupedCompany) => {
 });
 
 // Sort companies: open roles first, then most recent activity.
-const sortedCompanies: GroupedCompany[] = Object.values(groupedWork).sort(
-	(a: GroupedCompany, b: GroupedCompany) => {
-		const aSortKey = getCompanySortKey(a);
-		const bSortKey = getCompanySortKey(b);
+const sortedCompanies: GroupedCompany[] = Object.values(groupedWork)
+	.map((company) => ({
+		company,
+		sortKey: getCompanySortKey(company),
+	}))
+	.sort((a, b) => {
+		const { sortKey: aSortKey } = a;
+		const { sortKey: bSortKey } = b;
 
 		if (aSortKey.hasCurrentRole !== bSortKey.hasCurrentRole) {
 			return aSortKey.hasCurrentRole ? -1 : 1;
 		}
 
 		return bSortKey.latestRelevantDate - aSortKey.latestRelevantDate;
-	},
-);
+	})
+	.map((entry) => entry.company);
 ---
 
 <elegant-jobs>
@@ -534,5 +541,7 @@ const sortedCompanies: GroupedCompany[] = Object.values(groupedWork).sort(
 		}
 	}
 
-	customElements.define('elegant-jobs', ElegantJobs);
+	if (!customElements.get('elegant-jobs')) {
+		customElements.define('elegant-jobs', ElegantJobs);
+	}
 </script>

--- a/packages/shared/src/i18n/components/LocaleSelect.astro
+++ b/packages/shared/src/i18n/components/LocaleSelect.astro
@@ -149,5 +149,7 @@ const localesData = JSON.stringify(LOCALES);
     }
   }
 
-  customElements.define('locale-select', LocaleSelect);
+  if (!customElements.get('locale-select')) {
+    customElements.define('locale-select', LocaleSelect);
+  }
 </script>

--- a/packages/shared/src/layouts/Layout.astro
+++ b/packages/shared/src/layouts/Layout.astro
@@ -97,6 +97,14 @@ const getHostname = (urlStr?: string) => {
 		return "";
 	}
 };
+
+const isLocalhostHost = (hostname: string): boolean => {
+	return hostname === "localhost" || hostname === "127.0.0.1";
+};
+
+const alternatesOrigin =
+	Astro.site && !isLocalhostHost(Astro.site.hostname) ? Astro.site.origin : "";
+const canonicalHref = `${alternatesOrigin}${Astro.url.pathname}`;
 // Show search only on blog pages (paths that include '/blog')
 const showSearch = Astro.url?.pathname?.includes("/blog");
 ---
@@ -191,7 +199,7 @@ const showSearch = Astro.url?.pathname?.includes("/blog");
     <link rel="dns-prefetch" href="https://newassets.hcaptcha.com" />
 
     <!-- SEO: Canonical URL (clean, without query parameters) -->
-    <link rel="canonical" href={`${Astro.url.origin}${Astro.url.pathname}`} />
+    <link rel="canonical" href={canonicalHref} />
 
     <!-- Additional SEO meta tags -->
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
@@ -204,7 +212,7 @@ const showSearch = Astro.url?.pathname?.includes("/blog");
         <link
           rel="alternate"
           hreflang={LOCALES[props.lang].lang || props.lang}
-          href={Astro.site?.origin + props.path}
+          href={`${alternatesOrigin}${props.path}`}
         />
       ))
     }

--- a/packages/shared/src/layouts/Layout.astro
+++ b/packages/shared/src/layouts/Layout.astro
@@ -35,6 +35,7 @@ import {
 	STORAGE_KEY,
 } from "@/configs/theme.consts";
 import LocaleSuggest from "@/i18n/components/LocaleSuggest.astro";
+import { isLocalOrPrivateHostname } from "@/utils/public-origin";
 import alkatraRegularWoff2 from "../assets/font/alkatra/alkatra-v3-latin-regular.woff2";
 
 interface Props {
@@ -99,7 +100,7 @@ const getHostname = (urlStr?: string) => {
 };
 
 const isLocalhostHost = (hostname: string): boolean => {
-	return hostname === "localhost" || hostname === "127.0.0.1";
+	return isLocalOrPrivateHostname(hostname);
 };
 
 const alternatesOrigin =

--- a/packages/shared/src/utils/public-origin.test.ts
+++ b/packages/shared/src/utils/public-origin.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { getPublicOrigin, isLocalOrPrivateHostname } from "./public-origin";
+
+describe("isLocalOrPrivateHostname", () => {
+	it("should return true for localhost", () => {
+		expect(isLocalOrPrivateHostname("localhost")).toBe(true);
+		expect(isLocalOrPrivateHostname("my.localhost")).toBe(true);
+		expect(isLocalOrPrivateHostname("localhost.localdomain")).toBe(true);
+	});
+
+	it("should return true for .local hostnames", () => {
+		expect(isLocalOrPrivateHostname("my-device.local")).toBe(true);
+	});
+
+	it("should return true for loopback addresses", () => {
+		expect(isLocalOrPrivateHostname("127.0.0.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("127.0.1.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("::1")).toBe(true);
+		expect(isLocalOrPrivateHostname("0:0:0:0:0:0:0:1")).toBe(true);
+		expect(isLocalOrPrivateHostname("0.0.0.0")).toBe(true);
+	});
+
+	it("should return true for IPv4 private ranges", () => {
+		expect(isLocalOrPrivateHostname("10.0.0.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("172.16.0.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("172.31.255.255")).toBe(true);
+		expect(isLocalOrPrivateHostname("192.168.1.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("169.254.0.1")).toBe(true);
+	});
+
+	it("should return false for public hostnames", () => {
+		expect(isLocalOrPrivateHostname("google.com")).toBe(false);
+		expect(isLocalOrPrivateHostname("fcd.com")).toBe(false);
+		expect(isLocalOrPrivateHostname("yunielacosta.com")).toBe(false);
+		expect(isLocalOrPrivateHostname("8.8.8.8")).toBe(false);
+	});
+
+	it("should return true for IPv6 ULA (fc00::/7)", () => {
+		expect(isLocalOrPrivateHostname("fc00::1")).toBe(true);
+		expect(
+			isLocalOrPrivateHostname("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+		).toBe(true);
+	});
+
+	it("should return true for IPv6 Link-Local (fe80::/10)", () => {
+		expect(isLocalOrPrivateHostname("fe80::1")).toBe(true);
+		expect(
+			isLocalOrPrivateHostname("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+		).toBe(true);
+	});
+});
+
+describe("getPublicOrigin", () => {
+	it("should return empty string for undefined site", () => {
+		expect(getPublicOrigin(undefined)).toBe("");
+	});
+
+	it("should return empty string for local sites", () => {
+		expect(getPublicOrigin(new URL("http://localhost:4321"))).toBe("");
+	});
+
+	it("should return origin for public sites", () => {
+		expect(getPublicOrigin(new URL("https://yunielacosta.com"))).toBe(
+			"https://yunielacosta.com",
+		);
+	});
+});

--- a/packages/shared/src/utils/public-origin.test.ts
+++ b/packages/shared/src/utils/public-origin.test.ts
@@ -16,6 +16,7 @@ describe("isLocalOrPrivateHostname", () => {
 		expect(isLocalOrPrivateHostname("127.0.0.1")).toBe(true);
 		expect(isLocalOrPrivateHostname("127.0.1.1")).toBe(true);
 		expect(isLocalOrPrivateHostname("::1")).toBe(true);
+		expect(isLocalOrPrivateHostname("[::1]")).toBe(true);
 		expect(isLocalOrPrivateHostname("0:0:0:0:0:0:0:1")).toBe(true);
 		expect(isLocalOrPrivateHostname("0.0.0.0")).toBe(true);
 	});
@@ -37,6 +38,7 @@ describe("isLocalOrPrivateHostname", () => {
 
 	it("should return true for IPv6 ULA (fc00::/7)", () => {
 		expect(isLocalOrPrivateHostname("fc00::1")).toBe(true);
+		expect(isLocalOrPrivateHostname("[fc00::1]")).toBe(true);
 		expect(
 			isLocalOrPrivateHostname("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
 		).toBe(true);
@@ -57,6 +59,10 @@ describe("getPublicOrigin", () => {
 
 	it("should return empty string for local sites", () => {
 		expect(getPublicOrigin(new URL("http://localhost:4321"))).toBe("");
+	});
+
+	it("should return empty string for non-http(s) protocols", () => {
+		expect(getPublicOrigin(new URL("ftp://example.com"))).toBe("");
 	});
 
 	it("should return origin for public sites", () => {

--- a/packages/shared/src/utils/public-origin.ts
+++ b/packages/shared/src/utils/public-origin.ts
@@ -1,0 +1,69 @@
+const toIpv4Octets = (hostname: string): number[] | null => {
+	if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname)) {
+		return null;
+	}
+
+	const octets = hostname.split(".").map((part) => Number(part));
+	if (octets.some((octet) => Number.isNaN(octet) || octet < 0 || octet > 255)) {
+		return null;
+	}
+
+	return octets;
+};
+
+export const isLocalOrPrivateHostname = (hostname: string): boolean => {
+	const value = hostname.toLowerCase();
+
+	if (
+		value === "localhost" ||
+		value.endsWith(".localhost") ||
+		value === "localhost.localdomain" ||
+		value.endsWith(".local") ||
+		value === "::1" ||
+		value === "0:0:0:0:0:0:0:1" ||
+		value === "0.0.0.0" ||
+		value.startsWith("127.")
+	) {
+		return true;
+	}
+
+	const octets = toIpv4Octets(value);
+	if (!octets) {
+		return false;
+	}
+
+	const [first, second] = octets;
+	if (first === 10) {
+		return true;
+	}
+
+	if (first === 172 && second >= 16 && second <= 31) {
+		return true;
+	}
+
+	if (first === 192 && second === 168) {
+		return true;
+	}
+
+	if (first === 169 && second === 254) {
+		return true;
+	}
+
+	return false;
+};
+
+export const getPublicOrigin = (site?: URL): string => {
+	if (!site) {
+		return "";
+	}
+
+	if (site.protocol !== "http:" && site.protocol !== "https:") {
+		return "";
+	}
+
+	if (isLocalOrPrivateHostname(site.hostname)) {
+		return "";
+	}
+
+	return site.origin;
+};

--- a/packages/shared/src/utils/public-origin.ts
+++ b/packages/shared/src/utils/public-origin.ts
@@ -27,6 +27,19 @@ export const isLocalOrPrivateHostname = (hostname: string): boolean => {
 		return true;
 	}
 
+	if (value.includes(":")) {
+		if (
+			value.startsWith("fc") ||
+			value.startsWith("fd") ||
+			value.startsWith("fe8") ||
+			value.startsWith("fe9") ||
+			value.startsWith("fea") ||
+			value.startsWith("feb")
+		) {
+			return true;
+		}
+	}
+
 	const octets = toIpv4Octets(value);
 	if (!octets) {
 		return false;

--- a/packages/shared/src/utils/public-origin.ts
+++ b/packages/shared/src/utils/public-origin.ts
@@ -16,6 +16,7 @@ export const isLocalOrPrivateHostname = (hostname: string): boolean => {
 	if (value.startsWith("[") && value.endsWith("]")) {
 		value = value.slice(1, -1);
 	}
+	value = value.replace(/\.+$/, "");
 
 	if (
 		value === "localhost" ||

--- a/packages/shared/src/utils/public-origin.ts
+++ b/packages/shared/src/utils/public-origin.ts
@@ -12,7 +12,10 @@ const toIpv4Octets = (hostname: string): number[] | null => {
 };
 
 export const isLocalOrPrivateHostname = (hostname: string): boolean => {
-	const value = hostname.toLowerCase();
+	let value = hostname.toLowerCase();
+	if (value.startsWith("[") && value.endsWith("]")) {
+		value = value.slice(1, -1);
+	}
 
 	if (
 		value === "localhost" ||
@@ -79,4 +82,22 @@ export const getPublicOrigin = (site?: URL): string => {
 	}
 
 	return site.origin;
+};
+
+export const getOriginAndOg = (
+	site: URL | undefined,
+	defaultLocale: string,
+): {
+	alternatesOrigin: string;
+	ogImage: string;
+	ogUrl: string;
+} => {
+	const alternatesOrigin = getPublicOrigin(site);
+	const baseOrigin = alternatesOrigin || "http://localhost";
+
+	return {
+		alternatesOrigin,
+		ogImage: `${baseOrigin}/ogp.png`,
+		ogUrl: `${baseOrigin}/${defaultLocale}/`,
+	};
 };

--- a/packages/shared/src/utils/resolveSiteUrl.ts
+++ b/packages/shared/src/utils/resolveSiteUrl.ts
@@ -2,7 +2,9 @@
 // Resolve the site URL from common hosting provider env vars.
 // Precedence (first found): VERCEL_URL, URL (Netlify), DEPLOY_PRIME_URL (Netlify PRs),
 // CF_PAGES_URL (Cloudflare Pages), SITE_URL (manual), SITE_URL (env)
-// Fallback: http://localhost:4321
+// Fallbacks:
+// - Production: https://yunielacosta.com
+// - Development: http://localhost:4321
 const trimTrailingSlashes = (value: string): string => {
 	let end = value.length;
 	while (end > 0 && value.at(end - 1) === "/") {
@@ -96,18 +98,22 @@ export const resolveSiteUrl = () => {
 	// Known provider env vars (checked in order of preference)
 	const candidates = [
 		process.env.SITE_URL,
+		process.env.DOMAIN,
 		process.env.VERCEL_PROJECT_PRODUCTION_URL, // Vercel production domain
 		process.env.VERCEL_URL, // vercel provides host without protocol
 		process.env.VERCEL_BRANCH_URL, // Vercel branch domain
 		process.env.URL, // Netlify exposes this
 		process.env.DEPLOY_PRIME_URL, // Netlify preview
 		process.env.CF_PAGES_URL, // Cloudflare Pages
-		process.env.HOST, // generic
 	];
 
 	for (const raw of candidates) {
 		if (!raw) continue;
 		return normalizeCandidate(String(raw));
+	}
+
+	if (process.env.NODE_ENV === "production") {
+		return "https://yunielacosta.com";
 	}
 
 	return "http://localhost:4321";


### PR DESCRIPTION
This pull request focuses on improving how canonical URLs, alternate links, and Open Graph meta tags are generated across the blog, portfolio, and shared layouts. The changes ensure that URLs are consistent, avoid using localhost in production, and sort experience entries more accurately. The most important changes are grouped below:

**SEO and URL Handling Improvements**

* Canonical URLs are now set to `/` or constructed from a clean origin and pathname, avoiding `Astro.site` or localhost values in production for `404.astro`, `index.astro`, and shared layouts. [[1]](diffhunk://#diff-b5eb5e485282b6e3a5ef95d7eb1e8370f643aee484b729b215b081ff850f03a6L8-R17) [[2]](diffhunk://#diff-b663b4d7e62ca5a44790b8388b62190157fcc731753a9bb19cf1e169939b4e92L194-R202)
* Alternate link and Open Graph meta tag URLs are generated using a new `alternatesOrigin` variable, which excludes localhost and uses the site origin when available, ensuring correct URLs in production. [[1]](diffhunk://#diff-01ad5bbf7ebcc569e068cc90b2cde5b2d1a3ef2715f45c6be188e42b447789b5L21-R30) [[2]](diffhunk://#diff-01ad5bbf7ebcc569e068cc90b2cde5b2d1a3ef2715f45c6be188e42b447789b5L36-R44) [[3]](diffhunk://#diff-01ad5bbf7ebcc569e068cc90b2cde5b2d1a3ef2715f45c6be188e42b447789b5L52-R61) [[4]](diffhunk://#diff-b663b4d7e62ca5a44790b8388b62190157fcc731753a9bb19cf1e169939b4e92L207-R215)
* The `resolveSiteUrl.ts` utility now includes `DOMAIN` in environment variable precedence, and falls back to `https://yunielacosta.com` for production, or `http://localhost:4321` for development, ensuring reliable site URL resolution. [[1]](diffhunk://#diff-e11d7ecaa3939df19b06ceb70da12223bbee5896f3c8678f073676126263e19fL5-R7) [[2]](diffhunk://#diff-e11d7ecaa3939df19b06ceb70da12223bbee5896f3c8678f073676126263e19fR101-R118)

**Experience Section Sorting Logic**

* Positions within each company are now sorted with current (open) roles first, then by recency, using new helper functions `isCurrentPosition` and `sortPositionsByRecency`. Companies are also sorted to prioritize those with open roles and most recent activity. [[1]](diffhunk://#diff-fc018734891c1e59b43686bddb09b1141f7efcb7716c2cd637006945c4198674R31-R73) [[2]](diffhunk://#diff-fc018734891c1e59b43686bddb09b1141f7efcb7716c2cd637006945c4198674L53-R111)

These changes collectively improve SEO, URL accuracy, and the user experience in listing work history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canonical URL, Open Graph meta, and alternate hreflang generation for more consistent SEO across pages.

* **New Features**
  * Experience section now prioritizes current positions, then past roles by recency.
  * New public-origin utilities to detect local/private hosts and produce safe public origins, OG image and URL values.

* **Tests**
  * Added unit tests covering public-origin and hostname detection logic.

* **Chores**
  * Simplified base URL handling and refined site URL fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->