### PR TITLE
Improve IPv6 detection and OG tag absolute URLs

### DIFF
--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -22,8 +22,10 @@ const langs = Object.keys(LOCALES);
 const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
 const alternatesOrigin = getPublicOrigin(Astro.site);
-const ogImage = `${alternatesOrigin}/ogp.png`;
-const ogUrl = `${alternatesOrigin}/${defaultLocale}/`;
+const fallbackOrigin = "http://localhost";
+const alternatesOriginWithFallback = alternatesOrigin || fallbackOrigin;
+const ogImage = `${alternatesOriginWithFallback}/ogp.png`;
+const ogUrl = `${alternatesOriginWithFallback}/${defaultLocale}/`;
 ---
 
 <html lang={DEFAULT_LOCALE}>

--- a/apps/portfolio/src/pages/index.astro
+++ b/apps/portfolio/src/pages/index.astro
@@ -22,8 +22,10 @@ const langs = Object.keys(LOCALES);
 const baseUrl = "/";
 const defaultLocale = DEFAULT_LOCALE;
 const alternatesOrigin = getPublicOrigin(Astro.site);
-const ogImage = `${alternatesOrigin}/ogp.png`;
-const ogUrl = `${alternatesOrigin}/${defaultLocale}/`;
+const fallbackOrigin = "http://localhost";
+const alternatesOriginWithFallback = alternatesOrigin || fallbackOrigin;
+const ogImage = `${alternatesOriginWithFallback}/ogp.png`;
+const ogUrl = `${alternatesOriginWithFallback}/${defaultLocale}/`;
 ---
 
 <html lang={DEFAULT_LOCALE}>

--- a/packages/shared/src/utils/public-origin.test.ts
+++ b/packages/shared/src/utils/public-origin.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { getPublicOrigin, isLocalOrPrivateHostname } from "./public-origin";
+
+describe("isLocalOrPrivateHostname", () => {
+	it("should return true for localhost", () => {
+		expect(isLocalOrPrivateHostname("localhost")).toBe(true);
+		expect(isLocalOrPrivateHostname("my.localhost")).toBe(true);
+		expect(isLocalOrPrivateHostname("localhost.localdomain")).toBe(true);
+	});
+
+	it("should return true for .local hostnames", () => {
+		expect(isLocalOrPrivateHostname("my-device.local")).toBe(true);
+	});
+
+	it("should return true for loopback addresses", () => {
+		expect(isLocalOrPrivateHostname("127.0.0.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("127.0.1.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("::1")).toBe(true);
+		expect(isLocalOrPrivateHostname("0:0:0:0:0:0:0:1")).toBe(true);
+		expect(isLocalOrPrivateHostname("0.0.0.0")).toBe(true);
+	});
+
+	it("should return true for IPv4 private ranges", () => {
+		expect(isLocalOrPrivateHostname("10.0.0.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("172.16.0.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("172.31.255.255")).toBe(true);
+		expect(isLocalOrPrivateHostname("192.168.1.1")).toBe(true);
+		expect(isLocalOrPrivateHostname("169.254.0.1")).toBe(true);
+	});
+
+	it("should return false for public hostnames", () => {
+		expect(isLocalOrPrivateHostname("google.com")).toBe(false);
+		expect(isLocalOrPrivateHostname("fcd.com")).toBe(false);
+		expect(isLocalOrPrivateHostname("yunielacosta.com")).toBe(false);
+		expect(isLocalOrPrivateHostname("8.8.8.8")).toBe(false);
+	});
+
+	it("should return true for IPv6 ULA (fc00::/7)", () => {
+		expect(isLocalOrPrivateHostname("fc00::1")).toBe(true);
+		expect(
+			isLocalOrPrivateHostname("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+		).toBe(true);
+	});
+
+	it("should return true for IPv6 Link-Local (fe80::/10)", () => {
+		expect(isLocalOrPrivateHostname("fe80::1")).toBe(true);
+		expect(
+			isLocalOrPrivateHostname("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+		).toBe(true);
+	});
+});
+
+describe("getPublicOrigin", () => {
+	it("should return empty string for undefined site", () => {
+		expect(getPublicOrigin(undefined)).toBe("");
+	});
+
+	it("should return empty string for local sites", () => {
+		expect(getPublicOrigin(new URL("http://localhost:4321"))).toBe("");
+	});
+
+	it("should return origin for public sites", () => {
+		expect(getPublicOrigin(new URL("https://yunielacosta.com"))).toBe(
+			"https://yunielacosta.com",
+		);
+	});
+});

--- a/packages/shared/src/utils/public-origin.ts
+++ b/packages/shared/src/utils/public-origin.ts
@@ -27,6 +27,19 @@ export const isLocalOrPrivateHostname = (hostname: string): boolean => {
 		return true;
 	}
 
+	if (value.includes(":")) {
+		if (
+			value.startsWith("fc") ||
+			value.startsWith("fd") ||
+			value.startsWith("fe8") ||
+			value.startsWith("fe9") ||
+			value.startsWith("fea") ||
+			value.startsWith("feb")
+		) {
+			return true;
+		}
+	}
+
 	const octets = toIpv4Octets(value);
 	if (!octets) {
 		return false;


### PR DESCRIPTION
Verified and fixed issues related to Open Graph tags and IPv6 detection.
1. Updated `packages/shared/src/utils/public-origin.ts` to include IPv6 ULA and Link-Local checks.
2. Added unit tests for the above utility.
3. Updated `apps/blog/src/pages/index.astro` and `apps/portfolio/src/pages/index.astro` to ensure `og:image` and `og:url` are always absolute URLs by using a fallback origin when the public origin is empty.
4. Confirmed that `packages/shared/src/components/sections/Experience.astro` already has proper custom element registration guards.

---
*PR created automatically by Jules for task [11813325180336781829](https://jules.google.com/task/11813325180336781829) started by @yacosta738*