### PR TITLE
fix: Blog Social Media Icons Visibility

### DIFF
--- a/packages/shared/src/components/molecules/SocialLinks.astro
+++ b/packages/shared/src/components/molecules/SocialLinks.astro
@@ -30,7 +30,7 @@ const {
                 aria-label={social.name}
                 class="inline-flex items-center justify-center p-0.5 text-foreground hover:text-brand-accent dark:text-foreground-muted dark:hover:text-brand-accent transition-opacity"
             >
-                <Icon name={social.icon} class="size-5" />
+                <Icon name={social.icon} class="size-4" />
             </a>
         </li>
     ))}

--- a/packages/shared/src/components/molecules/SocialLinks.astro
+++ b/packages/shared/src/components/molecules/SocialLinks.astro
@@ -28,7 +28,7 @@ const {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={social.name}
-                class="text-foreground hover:text-brand-accent dark:text-foreground-muted dark:hover:text-brand-accent transition-opacity"
+                class="inline-flex items-center justify-center p-0.5 text-foreground hover:text-brand-accent dark:text-foreground-muted dark:hover:text-brand-accent transition-opacity"
             >
                 <Icon name={social.icon} class="size-5" />
             </a>

--- a/packages/shared/src/components/molecules/SocialMediaShare.astro
+++ b/packages/shared/src/components/molecules/SocialMediaShare.astro
@@ -33,37 +33,37 @@ const socialMediaLinkShare: {
 	{
 		name: "𝕏 (aka Twitter)",
 		url: `https://x.com/intent/tweet?url=${url}&text=${title}${tags.length ? `&hashtags=${tags.join(",")}` : ""}`,
-		icon: "tabler:brand-x",
+		icon: "simple-icons:x",
 	},
 	{
 		name: "Facebook",
 		url: `https://www.facebook.com/sharer.php?u=${url}`,
-		icon: "tabler:brand-facebook",
+		icon: "simple-icons:facebook",
 	},
 	{
 		name: "LinkedIn",
 		url: `https://www.linkedin.com/sharing/share-offsite/?url=${url}`,
-		icon: "tabler:brand-linkedin",
+		icon: "simple-icons:linkedin",
 	},
 	{
 		name: "Reddit",
 		url: `https://reddit.com/submit?url=${url}&title=${title}`,
-		icon: "tabler:brand-reddit",
+		icon: "simple-icons:reddit",
 	},
 	{
 		name: "Telegram",
 		url: `https://t.me/share/url?url=${url}&text=${description}`,
-		icon: "tabler:brand-telegram",
+		icon: "simple-icons:telegram",
 	},
 	{
 		name: "WhatsApp",
 		url: `https://api.whatsapp.com/send?text=${title}%20${url}`,
-		icon: "tabler:brand-whatsapp",
+		icon: "simple-icons:whatsapp",
 	},
 	{
 		name: "Email",
 		url: `mailto:?subject=${title}&body=${description}%20${url}`,
-		icon: "tabler:mail",
+		icon: "lucide:mail",
 	},
 ];
 ---

--- a/packages/shared/src/components/molecules/SocialMediaShare.astro
+++ b/packages/shared/src/components/molecules/SocialMediaShare.astro
@@ -64,7 +64,7 @@ const socialMediaLinkShare: {
 		name: "Email",
 		url: `mailto:?subject=${title}&body=${description}%20${url}`,
 		icon: "lucide:mail",
-	}
+	},
 ];
 ---
 

--- a/packages/shared/src/components/molecules/SocialMediaShare.astro
+++ b/packages/shared/src/components/molecules/SocialMediaShare.astro
@@ -28,7 +28,7 @@ const {
 const socialMediaLinkShare: {
 	name: string;
 	url: string;
-	icon: string | "tabler:world";
+	icon: string | "mdi:earth";
 }[] = [
 	{
 		name: "𝕏 (aka Twitter)",
@@ -64,7 +64,7 @@ const socialMediaLinkShare: {
 		name: "Email",
 		url: `mailto:?subject=${title}&body=${description}%20${url}`,
 		icon: "lucide:mail",
-	},
+	}
 ];
 ---
 

--- a/packages/shared/src/components/organisms/BlogFooter.astro
+++ b/packages/shared/src/components/organisms/BlogFooter.astro
@@ -17,14 +17,14 @@ const socials = [
 	{
 		name: "Twitter",
 		url: "https://x.com/yacosta738",
-		icon: "tabler:brand-x",
+		icon: "simple-icons:x",
 	},
 	{
 		name: "GitHub",
 		url: "https://github.com/yacosta738",
-		icon: "tabler:brand-github",
+		icon: "simple-icons:github",
 	},
-	{ name: "RSS", url: translatePath("/rss.xml"), icon: "tabler:rss" },
+	{ name: "RSS", url: translatePath("/rss.xml"), icon: "lucide:rss" },
 ];
 
 const filteredNavLinks = filterMenuItems(navLinks);


### PR DESCRIPTION
The social media icons in the blog's share component and footer were not rendering correctly due to a combination of missing/incorrect icon names in the Tabler set and insufficient CSS flexbox layout for the icon containers.

This PR fixes the issue by:
1.  **Switching Icon Libraries**: Moved to `simple-icons` for social brands (X/Twitter, Facebook, LinkedIn, Reddit, Telegram, WhatsApp, GitHub) and `lucide` for utility icons (Mail, RSS). These sets are more reliable for these specific use cases within the `astro-icon` ecosystem.
2.  **Improving Icon Layout**: Updated the `SocialLinks` component to use `inline-flex` and proper centering, ensuring that the SVG icons have a valid container size and are correctly aligned.
3.  **Ensuring Consistency**: Applied the icon set updates to both the `SocialMediaShare` component (used in post headers and footers) and the `BlogFooter` component.

Visual verification was performed by generating screenshots of the blog post view and footer, confirming all icons are now visible and correctly styled. Build and type checks (`pnpm build`, `pnpm check`) pass successfully.

Fixes #1682

---
*PR created automatically by Jules for task [5947879290556645489](https://jules.google.com/task/5947879290556645489) started by @yacosta738*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated social media icons across sharing and footer components to a modern, consistent icon set.
  * Refined social link visuals: smaller icon size, inline-flex layout, centered alignment, and tighter spacing for improved appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->