### PR TITLE
fix(portfolio): update email address to use custom domain alias in profile and resume data

### DIFF
--- a/packages/shared/src/data/authors/en/yuniel-acosta.json
+++ b/packages/shared/src/data/authors/en/yuniel-acosta.json
@@ -1,6 +1,6 @@
 {
 	"name": "Yuniel Acosta Pérez",
-	"email": "yunielacosta738@gmail.com",
+	"email": "contact@yunielacosta.com",
 	"avatar": "/src/assets/images/me.webp",
 	"bio": "I'm a very outgoing and curious person, who's passionate about coding, space, nature, and sports. I enjoy creating awesome software, whether that be websites, applications, or anything in between. My goal is always to create products that deliver high performance.",
 	"location": "Valencia, Spain",

--- a/packages/shared/src/data/authors/es/yuniel-acosta.json
+++ b/packages/shared/src/data/authors/es/yuniel-acosta.json
@@ -1,6 +1,6 @@
 {
 	"name": "Yuniel Acosta Pérez",
-	"email": "yunielacosta738@gmail.com",
+	"email": "contact@yunielacosta.com",
 	"avatar": "/src/assets/images/me.webp",
 	"bio": "Soy una persona muy extrovertida y curiosa, apasionado por la codificación, el espacio, la naturaleza y los deportes. Disfruto creando software asombroso, ya sean sitios web o aplicaciones. Mi objetivo es siempre producir productos que ofrezcan un alto rendimiento. Estoy interesado en nuevas oportunidades en especial en proyectos grandes y ambiciosos.",
 	"location": "Valencia, España",

--- a/packages/shared/src/data/resume/en/resume.json
+++ b/packages/shared/src/data/resume/en/resume.json
@@ -1,7 +1,7 @@
 {
 	"awards": [],
 	"basics": {
-		"email": "yunielacosta738@gmail.com",
+		"email": "contact@yunielacosta.com",
 		"image": "/me.webp",
 		"label": "Experienced software engineer skilled in front-end and back-end technologies. Proficient in software design principles, design patterns, and clean architectures.",
 		"location": {

--- a/packages/shared/src/data/resume/es/resume.json
+++ b/packages/shared/src/data/resume/es/resume.json
@@ -1,7 +1,7 @@
 {
 	"awards": [],
 	"basics": {
-		"email": "yunielacosta738@gmail.com",
+		"email": "contact@yunielacosta.com",
 		"image": "/me.webp",
 		"label": "Ingeniero de software experimentado en tecnologías frontend y backend. Dominio de principios de diseño de software, patrones de diseño y arquitecturas limpias.",
 		"location": {


### PR DESCRIPTION
This pull request updates the contact email address for Yuniel Acosta Pérez across both English and Spanish author and resume data files to use a new professional email.

Contact information updates:

* Updated the `email` field to `contact@yunielacosta.com` in the English author profile (`yuniel-acosta.json`).
* Updated the `email` field to `contact@yunielacosta.com` in the Spanish author profile (`yuniel-acosta.json`).
* Updated the `email` field to `contact@yunielacosta.com` in the English resume data (`resume.json`).
* Updated the `email` field to `contact@yunielacosta.com` in the Spanish resume data (`resume.json`).