### PR TITLE
fix(ui): update dark mode styling for language selector and sync theme on page swap

### DIFF
--- a/packages/shared/src/components/organisms/Header.astro
+++ b/packages/shared/src/components/organisms/Header.astro
@@ -100,14 +100,14 @@ const t = useTranslations(currentLocale);
 		color: var(--color-foreground);
 	}
 
-	:global(.dark) header.scrolled {
+	.dark header.scrolled {
 		background-color: rgba(17,34,51,0.75);
 		border-bottom: 1px solid rgba(35,53,84,0.3);
 	}
 
-	:global(.dark) header.scrolled #site-title,
-	:global(.dark) header.scrolled nav a,
-	:global(.dark) header.scrolled button:not([class*="bg-"]) {
+	.dark header.scrolled #site-title,
+	.dark header.scrolled nav a,
+	.dark header.scrolled button:not([class*="bg-"]) {
 		color: var(--color-foreground);
 	}
 

--- a/packages/shared/src/layouts/Layout.astro
+++ b/packages/shared/src/layouts/Layout.astro
@@ -163,7 +163,23 @@ const showSearch = Astro.url?.pathname?.includes("/blog");
         };
       };
 
+      const syncThemeToIncomingDocument = (newDocument) => {
+        if (!newDocument?.documentElement) return;
+
+        const isDark = document.documentElement.classList.contains("dark");
+        newDocument.documentElement.classList.toggle("dark", isDark);
+
+        const incomingThemeColor = newDocument.getElementById("theme-color");
+        if (incomingThemeColor) {
+          incomingThemeColor.setAttribute("content", isDark ? DARK_COLOR : LIGHT_COLOR);
+        }
+      };
+
       initTheme();
+
+      document.addEventListener('astro:before-swap', (event) => {
+        syncThemeToIncomingDocument(event.newDocument);
+      });
 
       document.addEventListener('astro:after-swap', initTheme);
 


### PR DESCRIPTION
This pull request improves theme synchronization and refines dark mode styling for the site header. The most important changes are grouped below:

**Theme synchronization enhancements:**

* Added a `syncThemeToIncomingDocument` function in `Layout.astro` to ensure the dark mode class and theme color meta tag are correctly transferred to incoming documents during client-side navigation.
* Registered an event listener for `astro:before-swap` to invoke theme synchronization before Astro swaps the document, ensuring seamless theme consistency across page transitions.

**Styling refinements for dark mode:**

* Updated CSS selectors in `Header.astro` to use `.dark` instead of `:global(.dark)`, simplifying and clarifying dark mode styles for the header and its elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dark mode theme now persists correctly during page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->