### PR TITLE
chore: downgrade actions/checkout and actions/setup-node to v4 for consistency

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Get cache keys
         id: cache-keys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       cache-key: ${{ steps.setup.outputs.cache-hit }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
         project: [portfolio, blog, api]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup monorepo
         uses: ./.github/actions/setup
@@ -95,7 +95,7 @@ jobs:
         project: [portfolio, blog, api]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup monorepo
         uses: ./.github/actions/setup
@@ -141,7 +141,7 @@ jobs:
             browser: chromium
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup monorepo
         uses: ./.github/actions/setup
@@ -175,7 +175,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -271,7 +271,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Generate pipeline summary
         run: |

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -34,7 +34,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup monorepo
         uses: ./.github/actions/setup
@@ -65,7 +65,7 @@ jobs:
       url: https://api.yacosta.dev
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup monorepo
         uses: ./.github/actions/setup

--- a/.github/workflows/deploy-portfolio.yml
+++ b/.github/workflows/deploy-portfolio.yml
@@ -36,7 +36,7 @@ jobs:
       name: ${{ inputs.environment || 'production' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup monorepo
         uses: ./.github/actions/setup
@@ -72,7 +72,7 @@ jobs:
       url: ${{ steps.deploy.outputs.url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Download build artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/image-actions.yml
+++ b/.github/workflows/image-actions.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Token
         uses: ./.github/actions/setup-token

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Restore lychee cache
         id: restore-cache

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,7 +49,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Setup monorepo
         uses: ./.github/actions/setup
@@ -74,7 +74,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
 
 env:
   NODE_VERSION: '22'
+  PNPM_VERSION: '10.32.1'
 
 jobs:
   test:
@@ -21,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -30,6 +31,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -58,7 +60,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: true
@@ -67,6 +69,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Verify authentication
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use earlier, stable major versions of the `actions/checkout` and `actions/setup-node` actions, and introduces explicit versioning for `pnpm` in the release workflow. These changes improve workflow stability and ensure consistent environment setup across CI/CD pipelines.

**Actions version updates:**

* Replaces all instances of `actions/checkout@v6` with `actions/checkout@v4` across workflow files, including CI, deployment, image actions, links, Playwright, SonarCloud, and cache cleanup workflows. [[1]](diffhunk://#diff-53934a34575d31176498532fef664b861a9d4665aa52ae95fa954bda1638fb44L31-R31) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL38-R38) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL70-R70) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL98-R98) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL144-R144) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL178-R178) [[7]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL274-R274) [[8]](diffhunk://#diff-c4bfea4c11747030aa4c75acb9480a60e04fd86766196128fe7250b069f022a3L37-R37) [[9]](diffhunk://#diff-c4bfea4c11747030aa4c75acb9480a60e04fd86766196128fe7250b069f022a3L68-R68) [[10]](diffhunk://#diff-11e4d35af992cc6bd4b651fcab070b713d7fd73cf28a84b65ea2066a4207ed21L39-R39) [[11]](diffhunk://#diff-11e4d35af992cc6bd4b651fcab070b713d7fd73cf28a84b65ea2066a4207ed21L75-R75) [[12]](diffhunk://#diff-19bf8df09d0abd3bec71d824df9f85b4eecd112630b7da3fedbcddec1a798365L25-R25) [[13]](diffhunk://#diff-a618bbaa9618d3ffa70846c5371ca23ea8f71f3370d3aa5be5d2cf39b42b207bL19-R19) [[14]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3L52-R52) [[15]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3L77-R77) [[16]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R25) [[17]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L61-R63) [[18]](diffhunk://#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bceL20-R20)
* Updates `actions/setup-node` from `v6` to `v4` in the custom composite action (`.github/actions/setup/action.yml`).

**Environment and setup improvements:**

* Adds a `PNPM_VERSION` environment variable (`10.32.1`) to the release workflow and passes it to the setup action, ensuring consistent `pnpm` version usage during release and publish jobs. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R14) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R34) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R72)

These updates help standardize the CI/CD environment and reduce the risk of unexpected changes due to breaking changes in major action versions.