### PR TITLE
fix(blog): route blog links and guard content refs

### DIFF
--- a/apps/blog/src/pages/[lang]/index.astro
+++ b/apps/blog/src/pages/[lang]/index.astro
@@ -62,7 +62,7 @@ const indexUrl = translatePath("/");
 							image={post.cover}
 							title={post.title}
 							description={post.description}
-							url={getBlogPostUrl(post, currentLocale)}
+							url={getBlogPostUrl(post, currentLocale, Astro.site?.origin)}
 							loading="eager"
 						/>
 					))}

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -55,7 +55,7 @@ const indexUrl = translatePath("/");
 							image={post.cover}
 							title={post.title}
 							description={post.description}
-							url={getBlogPostUrl(post, currentLocale)}
+							url={getBlogPostUrl(post, currentLocale, Astro.site?.origin)}
 							loading="eager"
 						/>
 					))}

--- a/packages/shared/src/components/atoms/ByAuthor.astro
+++ b/packages/shared/src/components/atoms/ByAuthor.astro
@@ -4,18 +4,24 @@ import type Author from "@/core/author/author.model";
 import { type Lang, useTranslatedPath, useTranslations } from "@/i18n";
 import { cleanEntityId } from "@/lib/collection.entity";
 import { cn } from "@/lib/utils";
+import { buildBlogUrl, getBlogBaseUrl } from "@/utils/blog-url";
 
 interface Props extends HTMLAttributes<"div"> {
 	author: Author;
 	currentLocale: Lang;
+	baseUrl?: string;
 }
-const { author, currentLocale, ...attrs } = Astro.props;
+const { author, currentLocale, baseUrl, ...attrs } = Astro.props;
 
 const t = useTranslations(currentLocale);
 const translatePath = useTranslatedPath(currentLocale);
-const authorPath = translatePath(
-	`/author/${cleanEntityId(author.slug).toLowerCase()}`,
-);
+const blogBaseUrl = baseUrl ? getBlogBaseUrl(baseUrl) : "";
+const authorPath = blogBaseUrl
+	? buildBlogUrl(
+			translatePath(`/author/${cleanEntityId(author.slug).toLowerCase()}`),
+			baseUrl,
+		)
+	: translatePath(`/author/${cleanEntityId(author.slug).toLowerCase()}`);
 ---
 
 <div

--- a/packages/shared/src/components/molecules/BlogGridContainer.astro
+++ b/packages/shared/src/components/molecules/BlogGridContainer.astro
@@ -126,7 +126,11 @@ for (let i = 0; i < totalPosts; i++) {
       }
 
       // Get the URL and link attributes for the post
-      const postUrl = getBlogPostUrl(post, currentLocale);
+		const postUrl = getBlogPostUrl(
+			post,
+			currentLocale,
+			Astro.site?.origin,
+		);
       const target = getBlogPostTarget(post);
       const rel = getBlogPostRel(post);
 

--- a/packages/shared/src/components/molecules/Menu.astro
+++ b/packages/shared/src/components/molecules/Menu.astro
@@ -9,6 +9,7 @@ import { resolveNavigationMenuHref } from "@/core/menu/menu.service";
 import { useTranslatedPath, useTranslations } from "@/i18n";
 import LocaleSelect from "@/i18n/components/LocaleSelect.astro";
 import { cn } from "@/lib/utils";
+import { buildBlogUrl, getBlogBaseUrl } from "@/utils/blog-url";
 
 interface Props extends HTMLAttributes<"nav"> {
 	drawer?: boolean;
@@ -27,6 +28,10 @@ import { resolveLocaleFromUrl } from "@/i18n/utils/resolveLocaleFromUrl";
 const currentLocale = resolveLocaleFromUrl(Astro.url, Astro.params.lang);
 const t = useTranslations(currentLocale);
 const translatePath = useTranslatedPath(currentLocale);
+const siteOrigin = Astro.site?.origin || DOMAIN;
+const blogBaseUrl = siteOrigin ? getBlogBaseUrl(siteOrigin) : "";
+const blogHref = (path: string) =>
+	blogBaseUrl ? buildBlogUrl(path, siteOrigin) : path;
 ---
 
 <nav
@@ -68,7 +73,7 @@ const translatePath = useTranslatedPath(currentLocale);
 			class="rounded bg-transparent p-2 text-sm text-foreground-muted hover:text-brand-accent hover:bg-brand-accent/10 transition-all duration-200 border border-transparent hover:border-brand-accent"
 			aria-label={t("rssFeed")}
 			target="_blank"
-			href={translatePath("/rss.xml")}
+			href={blogHref(translatePath("/rss.xml"))}
 		>
 			<Icon name="lucide:rss" class="h-5 w-5" aria-hidden="true" />
 		</a>

--- a/packages/shared/src/components/molecules/WidgetRecentPost.astro
+++ b/packages/shared/src/components/molecules/WidgetRecentPost.astro
@@ -35,7 +35,11 @@ const t = useTranslations(currentLocale);
 				}
 				{recentPosts
 					.map((post) => {
-						const url = getBlogPostUrl(post, currentLocale);
+						const url = getBlogPostUrl(
+							post,
+							currentLocale,
+							Astro.site?.origin,
+						);
 						return { post, url };
 					})
 					.filter(({ url }) => {

--- a/packages/shared/src/components/organisms/PostCard.astro
+++ b/packages/shared/src/components/organisms/PostCard.astro
@@ -4,6 +4,7 @@ import { routes } from "@/configs/route.path";
 import type Article from "@/core/article/article.model";
 import { type Lang, useTranslatedPath, useTranslations } from "@/i18n";
 import { cleanEntityId } from "@/lib/collection.entity";
+import { buildBlogUrl, getBlogBaseUrl } from "@/utils/blog-url";
 
 const currentLocale = Astro.currentLocale as Lang;
 const t = useTranslations(currentLocale);
@@ -27,7 +28,13 @@ const formatMonthForDisplay = (date: Date) => {
 	return new Intl.DateTimeFormat(currentLocale, { month: "long" }).format(date);
 };
 
-const contentLink = translatePath(`/${cleanEntityId(id).toLowerCase()}/`);
+const siteOrigin = Astro.site?.origin;
+const blogBaseUrl = siteOrigin ? getBlogBaseUrl(siteOrigin) : "";
+const buildBlogHref = (path: string) =>
+	blogBaseUrl ? buildBlogUrl(path, siteOrigin) : path;
+const contentLink = buildBlogHref(
+	translatePath(`/${cleanEntityId(id).toLowerCase()}/`),
+);
 ---
 
 <article
@@ -53,12 +60,18 @@ const contentLink = translatePath(`/${cleanEntityId(id).toLowerCase()}/`);
       </h3>
       <p class="font-body text-lg leading-[140%] tracking-normal mb-3 max-w-[430px] w-full line-clamp-4 text-foreground-muted">{description}</p>
       <div class="flex items-center flex-wrap gap-2">
-                    <ByAuthor author={author} currentLocale={currentLocale} />
+							<ByAuthor
+								author={author}
+								currentLocale={currentLocale}
+								baseUrl={siteOrigin}
+							/>
           <div class="flex items-center flex-wrap gap-2">
               {tags?.map((tag) => (
                 <a
                   class="w-fit inline text-[9px] tracking-widest uppercase transition-colors hover:opacity-80 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none text-foreground-muted"
-                  href={translatePath(`/${routes.tag}/${tag.slug}`)}
+									href={buildBlogHref(
+										translatePath(`/${routes.tag}/${tag.slug}`),
+									)}
                   aria-label={t("post.aria.tag", { tag: tag.title })}
                 >
                   {tag.title}

--- a/packages/shared/src/core/article/article.mapper.ts
+++ b/packages/shared/src/core/article/article.mapper.ts
@@ -4,6 +4,48 @@ import { toCategory } from "../category";
 import { toTag } from "../tag";
 import type Article from "./article.model";
 
+const isStringReference = (value: unknown): value is string =>
+	typeof value === "string" && value.trim().length > 0;
+
+const isObjectReference = (
+	value: unknown,
+): value is { collection: string; id: string } =>
+	typeof value === "object" &&
+	value !== null &&
+	"collection" in value &&
+	"id" in value &&
+	typeof (value as { collection?: unknown }).collection === "string" &&
+	(value as { collection: string }).collection.trim().length > 0 &&
+	typeof (value as { id?: unknown }).id === "string" &&
+	(value as { id: string }).id.trim().length > 0;
+
+const isValidReference = (
+	value: unknown,
+): value is string | { collection: string; id: string } =>
+	isStringReference(value) || isObjectReference(value);
+
+type EntryWithId = { id?: string };
+
+const mapEntriesSafe = async <T extends EntryWithId, U>(
+	entries: T[],
+	mapper: (entry: T) => Promise<U>,
+	context: string,
+): Promise<U[]> => {
+	const results = await Promise.allSettled(entries.map(mapper));
+	return results.flatMap((result, index) => {
+		if (result.status === "fulfilled") {
+			return [result.value];
+		}
+		const id = entries[index]?.id ?? "unknown";
+		const message =
+			result.reason instanceof Error
+				? result.reason.message
+				: String(result.reason);
+		console.warn(`Skipping ${context} entry ${id}: ${message}`);
+		return [];
+	});
+};
+
 /**
  * Maps a collection entry of type "articles" to an Article object.
  *
@@ -15,9 +57,16 @@ import type Article from "./article.model";
 export async function toArticle(
 	articleData: CollectionEntry<"articles">,
 ): Promise<Article> {
-	const author = await getEntry(articleData.data.author);
-	const category = await getEntry(articleData.data.category);
-	const tags = await getEntries(articleData.data.tags);
+	const authorRef = articleData.data.author;
+	const categoryRef = articleData.data.category;
+	const author = isValidReference(authorRef)
+		? await getEntry(authorRef)
+		: undefined;
+	const category = isValidReference(categoryRef)
+		? await getEntry(categoryRef)
+		: undefined;
+	const tagRefs = (articleData.data.tags ?? []).filter(isValidReference);
+	const tags = await getEntries(tagRefs);
 	const tagEntries = tags.filter((tag): tag is CollectionEntry<"tags"> =>
 		Boolean(tag),
 	);
@@ -57,7 +106,7 @@ export async function toArticle(
 export async function toArticles(
 	articles: CollectionEntry<"articles">[],
 ): Promise<Article[]> {
-	return Promise.all(articles.map(toArticle));
+	return mapEntriesSafe(articles, toArticle, "article");
 }
 
 /**
@@ -71,9 +120,16 @@ export async function toArticles(
 export async function toExternalArticle(
 	articleData: CollectionEntry<"externalArticles">,
 ): Promise<Article> {
-	const author = await getEntry(articleData.data.author);
-	const category = await getEntry(articleData.data.category);
-	const tags = await getEntries(articleData.data.tags);
+	const authorRef = articleData.data.author;
+	const categoryRef = articleData.data.category;
+	const author = isValidReference(authorRef)
+		? await getEntry(authorRef)
+		: undefined;
+	const category = isValidReference(categoryRef)
+		? await getEntry(categoryRef)
+		: undefined;
+	const tagRefs = (articleData.data.tags ?? []).filter(isValidReference);
+	const tags = await getEntries(tagRefs);
 	const tagEntries = tags.filter((tag): tag is CollectionEntry<"tags"> =>
 		Boolean(tag),
 	);
@@ -115,7 +171,7 @@ export async function toExternalArticle(
 export async function toExternalArticles(
 	articles: CollectionEntry<"externalArticles">[],
 ): Promise<Article[]> {
-	return Promise.all(articles.map(toExternalArticle));
+	return mapEntriesSafe(articles, toExternalArticle, "external article");
 }
 
 /**
@@ -132,11 +188,17 @@ export async function toNotionArticle(
 	const fallbackAuthorId = articleData.id.startsWith("es/")
 		? "es/yuniel-acosta-perez"
 		: "en/yuniel-acosta-perez";
-	const author =
-		(await getEntry(articleData.data.author)) ??
-		(await getEntry(fallbackAuthorId));
-	const category = await getEntry(articleData.data.category);
-	const tags = await getEntries(articleData.data.tags);
+	const authorRef = articleData.data.author;
+	const categoryRef = articleData.data.category;
+	const primaryAuthor = isValidReference(authorRef)
+		? await getEntry(authorRef)
+		: undefined;
+	const author = primaryAuthor ?? (await getEntry(fallbackAuthorId));
+	const category = isValidReference(categoryRef)
+		? await getEntry(categoryRef)
+		: undefined;
+	const tagRefs = (articleData.data.tags ?? []).filter(isValidReference);
+	const tags = await getEntries(tagRefs);
 	const tagEntries = tags.filter((tag): tag is CollectionEntry<"tags"> =>
 		Boolean(tag),
 	);
@@ -145,7 +207,32 @@ export async function toNotionArticle(
 		throw new Error(`Author not found for notion article: ${articleData.id}`);
 	}
 	if (!category) {
-		throw new Error(`Category not found for notion article: ${articleData.id}`);
+		const fallbackCategoryId = articleData.id.startsWith("es/")
+			? "es/software-development"
+			: "en/software-development";
+		const fallbackCategory = await getEntry(fallbackCategoryId);
+		if (!fallbackCategory) {
+			throw new Error(
+				`Category not found for notion article: ${articleData.id}`,
+			);
+		}
+		return {
+			id: articleData.id,
+			title: articleData.data.title,
+			description: articleData.data.description,
+			author: toAuthor(author),
+			cover: articleData.data.cover,
+			tags: tagEntries.map(toTag),
+			category: toCategory(fallbackCategory),
+			featured: articleData.data.featured ?? false,
+			draft: articleData.data.draft ?? false,
+			body: articleData.body ?? "",
+			date: new Date(articleData.data.date),
+			lastModified: articleData.data.lastModified
+				? new Date(articleData.data.lastModified)
+				: undefined,
+			entry: articleData,
+		};
 	}
 
 	return {
@@ -176,5 +263,5 @@ export async function toNotionArticle(
 export async function toNotionArticles(
 	articles: CollectionEntry<"notionArticles">[],
 ): Promise<Article[]> {
-	return Promise.all(articles.map(toNotionArticle));
+	return mapEntriesSafe(articles, toNotionArticle, "notion article");
 }

--- a/packages/shared/src/core/menu/menu.service.ts
+++ b/packages/shared/src/core/menu/menu.service.ts
@@ -1,80 +1,9 @@
+import { getBlogBaseUrl, normalizeBaseUrl } from "@/utils/blog-url";
 import type { MenuItem } from "./menu.type";
 
 type NavigationMenuLink = {
 	id: string;
 	link: string;
-};
-
-const normalizeBaseUrl = (value?: string): string => {
-	if (!value) return "";
-	const trimmed = value.trim();
-	if (!trimmed) return "";
-	const withoutSlash = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
-	if (/^https?:\/\//i.test(withoutSlash)) return withoutSlash;
-	return `https://${withoutSlash}`;
-};
-
-const buildBlogBaseUrl = (baseUrl: string): string => {
-	if (!baseUrl) return "";
-	try {
-		const url = new URL(baseUrl);
-		if (!url.hostname.startsWith("blog.")) {
-			url.hostname = `blog.${url.hostname}`;
-		}
-		return url.origin;
-	} catch {
-		return "";
-	}
-};
-
-/**
- * Check if hostname is localhost or loopback address
- */
-const isLocalhost = (hostname: string): boolean => {
-	return (
-		hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
-	);
-};
-
-/**
- * Get the blog base URL based on the environment
- * - Production: blog.yunielacosta.com (derived from domain)
- * - Development: localhost:4322 (blog port)
- */
-const getBlogBaseUrl = (domain?: string): string => {
-	// In production, use production blog URL
-	if (process.env.NODE_ENV === "production") {
-		const normalized = normalizeBaseUrl(domain);
-		// If no domain configured in production, use default
-		if (!normalized) {
-			return "https://blog.yunielacosta.com";
-		}
-		const blogUrl = buildBlogBaseUrl(normalized);
-		// If domain is malformed and buildBlogBaseUrl returns empty, use fallback
-		return blogUrl || "https://blog.yunielacosta.com";
-	}
-
-	// In development or when no domain is configured, use localhost:4322
-	// Normalize first to catch whitespace-only strings
-	const normalized = normalizeBaseUrl(domain);
-	if (!normalized) {
-		return "http://localhost:4322";
-	}
-
-	// If domain is localhost, use localhost:4322 for blog
-	try {
-		const url = new URL(normalized);
-		if (isLocalhost(url.hostname)) {
-			return "http://localhost:4322";
-		}
-	} catch {
-		// If URL parsing fails, return localhost as fallback
-		return "http://localhost:4322";
-	}
-
-	// In other dev environments, derive blog URL from domain
-	const blogUrl = buildBlogBaseUrl(normalized);
-	return blogUrl || "http://localhost:4322";
 };
 
 /**

--- a/packages/shared/src/i18n/i18n.ts
+++ b/packages/shared/src/i18n/i18n.ts
@@ -32,8 +32,13 @@ import { useTranslations } from "./utils";
  * translatePath('/en/about', 'en'); // returns '/en/about' (prevents duplicate prefixes)
  */
 export function useTranslatedPath(lang: Lang) {
-	return function translatePath(path: string, targetLang: Lang = lang): string {
-		return buildLocalePath(path, targetLang);
+	const fallbackLang = (lang || DEFAULT_LOCALE) as Lang;
+	return function translatePath(
+		path: string,
+		targetLang: Lang = fallbackLang,
+	): string {
+		const resolvedLang = (targetLang || fallbackLang) as Lang;
+		return buildLocalePath(path, resolvedLang);
 	};
 }
 

--- a/packages/shared/src/lib/blog-post.utils.ts
+++ b/packages/shared/src/lib/blog-post.utils.ts
@@ -1,6 +1,7 @@
 import type Article from "@/core/article/article.model";
 import type ExternalArticle from "@/core/external-article/external-article.model";
 import { type Lang, useTranslatedPath } from "@/i18n";
+import { buildBlogUrl } from "@/utils/blog-url";
 
 /**
  * Union type for both regular and external articles
@@ -24,13 +25,18 @@ export function isArticle(post: BlogPost): post is Article {
 /**
  * Get the URL for a blog post (internal slug or external link)
  */
-export function getBlogPostUrl(post: BlogPost, lang: Lang): string {
+export function getBlogPostUrl(
+	post: BlogPost,
+	lang: Lang,
+	domain?: string,
+): string {
 	if (isExternalArticle(post)) {
 		return post.link;
 	}
 	// For regular articles, create internal URL
 	const translatePath = useTranslatedPath(lang);
-	return translatePath(`/${post.id.split("/").slice(1).join("/")}`);
+	const path = translatePath(`/${post.id.split("/").slice(1).join("/")}`);
+	return domain ? buildBlogUrl(path, domain) : path;
 }
 
 /**

--- a/packages/shared/src/styles/pagefind.css
+++ b/packages/shared/src/styles/pagefind.css
@@ -1,3 +1,4 @@
+/* biome-ignore-all lint/complexity/noImportantStyles: pagefind overrides */
 .pagefind-ui {
 	--pagefind-ui-scale: 1;
 	--pagefind-ui-primary: var(--color-primary);

--- a/packages/shared/src/utils/blog-url.ts
+++ b/packages/shared/src/utils/blog-url.ts
@@ -1,0 +1,62 @@
+const normalizeBaseUrl = (value?: string): string => {
+	if (!value) return "";
+	const trimmed = value.trim();
+	if (!trimmed) return "";
+	const withoutSlash = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+	if (/^https?:\/\//i.test(withoutSlash)) return withoutSlash;
+	return `https://${withoutSlash}`;
+};
+
+const buildBlogBaseUrl = (baseUrl: string): string => {
+	if (!baseUrl) return "";
+	try {
+		const url = new URL(baseUrl);
+		if (!url.hostname.startsWith("blog.")) {
+			url.hostname = `blog.${url.hostname}`;
+		}
+		return url.origin;
+	} catch {
+		return "";
+	}
+};
+
+const isLocalhost = (hostname: string): boolean => {
+	return (
+		hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+	);
+};
+
+export const getBlogBaseUrl = (domain?: string): string => {
+	if (process.env.NODE_ENV === "production") {
+		const normalized = normalizeBaseUrl(domain);
+		if (!normalized) {
+			return "https://blog.yunielacosta.com";
+		}
+		const blogUrl = buildBlogBaseUrl(normalized);
+		return blogUrl || "https://blog.yunielacosta.com";
+	}
+
+	const normalized = normalizeBaseUrl(domain);
+	if (!normalized) {
+		return "http://localhost:4322";
+	}
+
+	try {
+		const url = new URL(normalized);
+		if (isLocalhost(url.hostname)) {
+			return "http://localhost:4322";
+		}
+	} catch {
+		return "http://localhost:4322";
+	}
+
+	const blogUrl = buildBlogBaseUrl(normalized);
+	return blogUrl || "http://localhost:4322";
+};
+
+export const buildBlogUrl = (path: string, domain?: string): string => {
+	const blogBaseUrl = getBlogBaseUrl(domain);
+	return blogBaseUrl ? `${blogBaseUrl}${path}` : path;
+};
+
+export { normalizeBaseUrl };


### PR DESCRIPTION
## Summary
- route portfolio blog links (posts/tags/authors/rss) to the blog host
- guard missing content references and fallback notion categories to avoid build failures
- add shared blog URL helper and i18n fallback; suppress pagefind !important lint

## Testing
- make preflight


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced blog URL construction to support absolute URLs with site origin across all components.
  * Added configurable blog base URL support for author links and post navigation.

* **Bug Fixes**
  * Improved article data resilience with fallback category handling when references are invalid.
  * Enhanced language path resolution with automatic fallback to default locale.

* **Documentation**
  * Added lint rule suppression comment for CSS overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->