### PR TITLE
fix: improve Sonar quality gate coverage and safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,10 @@ jobs:
       - name: Run targeted shared coverage for Sonar
         run: pnpm --filter=@portfolio/shared exec vitest run src/lib/seo/json-ld.test.ts src/core/tag/tag.mapper.test.ts src/i18n/types.test.ts src/i18n/ui.test.ts src/i18n/i18n.test.ts
 
+      - name: Normalize shared LCOV paths
+        run: |
+          node -e "const fs=require('node:fs'); const path='packages/shared/coverage/lcov.info'; if (fs.existsSync(path)) { const content=fs.readFileSync(path,'utf8').replace(/^SF:src\//gm,'SF:packages/shared/src/'); fs.writeFileSync(path, content); }"
+
       - name: Validate LCOV reports exist
         id: coverage-check
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Run targeted shared coverage for Sonar
-        run: pnpm --filter=@portfolio/shared exec vitest run src/lib/seo/json-ld.test.ts src/core/tag/tag.mapper.test.ts
+        run: pnpm --filter=@portfolio/shared exec vitest run src/lib/seo/json-ld.test.ts src/core/tag/tag.mapper.test.ts src/i18n/types.test.ts src/i18n/ui.test.ts src/i18n/i18n.test.ts
 
       - name: Validate LCOV reports exist
         id: coverage-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,16 +182,25 @@ jobs:
           path: coverage/
           merge-multiple: true
 
+      - name: Setup monorepo
+        uses: ./.github/actions/setup
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Run targeted shared coverage for Sonar
+        run: pnpm --filter=@portfolio/shared exec vitest run src/lib/seo/json-ld.test.ts src/core/tag/tag.mapper.test.ts
+
       - name: Validate LCOV reports exist
         id: coverage-check
         run: |
           ls -R coverage || true
-          if [ -n "$(find coverage -name 'lcov.info' -print -quit)" ]; then
+          ls -R packages/shared/coverage || true
+          if [ -n "$(find coverage packages -path '*/coverage/lcov.info' -print -quit 2>/dev/null)" ]; then
             echo "coverage_found=true" >> "$GITHUB_OUTPUT"
             echo "✅ LCOV reports detected."
           else
             echo "coverage_found=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️ No LCOV reports were found under coverage/. SonarCloud scan will be skipped."
+            echo "⚠️ No LCOV reports were found in downloaded artifacts or packages/*/coverage. SonarCloud scan will be skipped."
           fi
 
       - name: Validate Sonar token
@@ -214,11 +223,12 @@ jobs:
             -Dsonar.projectKey=yacosta738_yacosta738.github.io
             -Dsonar.organization=yacosta738
             -Dsonar.sources=apps,packages
-            -Dsonar.tests=apps
+            -Dsonar.tests=apps,packages
             -Dsonar.test.inclusions=**/*.test.ts,**/*.spec.ts,**/tests/**
-            -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info
+            -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info,packages/*/coverage/lcov.info
             -Dsonar.exclusions=**/dist/**,**/coverage/**,**/node_modules/**,**/.astro/**,apps/blog/src/data/**,packages/shared/src/data/**
             -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/__tests__/**,**/tests/**
+            -Dsonar.cpd.exclusions=**/content.config.ts,**/vitest.config.ts,**/playwright.config.ts,**/astro.config.mjs,**/organize-articles.js
 
       - name: SonarCloud Scan (Push/Main)
         id: sonar-main-scan
@@ -233,11 +243,12 @@ jobs:
             -Dsonar.projectKey=yacosta738_yacosta738.github.io
             -Dsonar.organization=yacosta738
             -Dsonar.sources=apps,packages
-            -Dsonar.tests=apps
+            -Dsonar.tests=apps,packages
             -Dsonar.test.inclusions=**/*.test.ts,**/*.spec.ts,**/tests/**
-            -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info
+            -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info,packages/*/coverage/lcov.info
             -Dsonar.exclusions=**/dist/**,**/coverage/**,**/node_modules/**,**/.astro/**,apps/blog/src/data/**,packages/shared/src/data/**
             -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/__tests__/**,**/tests/**
+            -Dsonar.cpd.exclusions=**/content.config.ts,**/vitest.config.ts,**/playwright.config.ts,**/astro.config.mjs,**/organize-articles.js
 
       - name: SonarCloud main scan warning
         if: steps.sonar-main-scan.outcome == 'failure'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Run targeted shared coverage for Sonar
         run: pnpm --filter=@portfolio/shared exec vitest run src/lib/seo/json-ld.test.ts src/core/tag/tag.mapper.test.ts src/i18n/types.test.ts src/i18n/ui.test.ts src/i18n/i18n.test.ts
 
+      - name: Normalize shared LCOV paths
+        run: |
+          node -e "const fs=require('node:fs'); const path='packages/shared/coverage/lcov.info'; if (fs.existsSync(path)) { const content=fs.readFileSync(path,'utf8').replace(/^SF:src\//gm,'SF:packages/shared/src/'); fs.writeFileSync(path, content); }"
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v5
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -34,7 +34,7 @@ jobs:
           upload-coverage: 'false'
 
       - name: Run targeted shared coverage for Sonar
-        run: pnpm --filter=@portfolio/shared exec vitest run src/lib/seo/json-ld.test.ts src/core/tag/tag.mapper.test.ts
+        run: pnpm --filter=@portfolio/shared exec vitest run src/lib/seo/json-ld.test.ts src/core/tag/tag.mapper.test.ts src/i18n/types.test.ts src/i18n/ui.test.ts src/i18n/i18n.test.ts
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v5

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -33,6 +33,9 @@ jobs:
           coverage: 'true'
           upload-coverage: 'false'
 
+      - name: Run targeted shared coverage for Sonar
+        run: pnpm --filter=@portfolio/shared exec vitest run src/lib/seo/json-ld.test.ts src/core/tag/tag.mapper.test.ts
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v5
         env:
@@ -42,9 +45,9 @@ jobs:
           args: >
             -Dsonar.projectKey=yacosta738_yacosta738.github.io
             -Dsonar.organization=yacosta738
-            -Dsonar.sources=apps/
-            -Dsonar.tests=apps/
+            -Dsonar.sources=apps,packages
+            -Dsonar.tests=apps,packages
             -Dsonar.test.inclusions=**/*.test.ts,**/*.spec.ts,**/tests/**
-            -Dsonar.javascript.lcov.reportPaths=apps/*/coverage/lcov.info
+            -Dsonar.javascript.lcov.reportPaths=apps/*/coverage/lcov.info,packages/*/coverage/lcov.info
             -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/__tests__/**,**/tests/**
             -Dsonar.cpd.exclusions=**/content.config.ts,**/vitest.config.ts,**/playwright.config.ts,**/astro.config.mjs,**/organize-articles.js

--- a/apps/blog/src/content.config.ts
+++ b/apps/blog/src/content.config.ts
@@ -57,7 +57,9 @@ const createNotionLoader = async () => {
 		.split(",")
 		.map((tag: string) => tag.trim())
 		.filter(Boolean);
-	const notionRehypePlugin = notionBlockFallbacks as unknown;
+	const notionRehypePlugin = notionBlockFallbacks as (
+		...args: unknown[]
+	) => unknown;
 	const notionTypeFilter = "Article";
 	const notionStatusFilter = "Ready";
 	const notionToday = new Date().toISOString().slice(0, 10);

--- a/apps/blog/src/i18n/i18n.ts
+++ b/apps/blog/src/i18n/i18n.ts
@@ -33,7 +33,9 @@ export function useTranslatedPath(lang: Lang) {
 	};
 }
 
-const ROUTE_LOCALE_KEYS = Object.keys(LOCALES) as Lang[];
+const ROUTE_LOCALE_KEYS = Object.keys(LOCALES).filter(
+	(lang): lang is Lang => lang in LOCALES,
+);
 
 export const ROUTE_LOCALES: Lang[] = SHOW_DEFAULT_LANG_IN_URL
 	? ROUTE_LOCALE_KEYS

--- a/apps/blog/src/lib/notion/notion-article.mapper.ts
+++ b/apps/blog/src/lib/notion/notion-article.mapper.ts
@@ -36,7 +36,8 @@ export type NotionArticleEntry = {
 	sourceId?: string;
 };
 
-const isLocale = (value: string): value is Lang => value in LOCALES;
+const isLocale = (value: string): value is Lang =>
+	Object.hasOwn(LOCALES, value);
 
 const trimHyphenEdges = (value: string): string => {
 	let start = 0;
@@ -254,12 +255,12 @@ const normalizeLocale = (value: string | undefined): Lang => {
 		return DEFAULT_LOCALE;
 	}
 
-	const normalized = value.toLowerCase();
-	if (isLocale(normalized)) {
-		return normalized;
+	const normalizedValue = value.toLowerCase();
+	if (isLocale(normalizedValue)) {
+		return normalizedValue;
 	}
 
-	const base = normalized.split("-")[0];
+	const base = value.split("-")[0]?.toLowerCase() ?? "";
 	if (isLocale(base)) {
 		return base;
 	}

--- a/apps/blog/src/lib/notion/notion-article.mapper.ts
+++ b/apps/blog/src/lib/notion/notion-article.mapper.ts
@@ -36,6 +36,23 @@ export type NotionArticleEntry = {
 	sourceId?: string;
 };
 
+const isLocale = (value: string): value is Lang => value in LOCALES;
+
+const trimHyphenEdges = (value: string): string => {
+	let start = 0;
+	let end = value.length;
+
+	while (start < end && value[start] === "-") {
+		start += 1;
+	}
+
+	while (end > start && value[end - 1] === "-") {
+		end -= 1;
+	}
+
+	return value.slice(start, end);
+};
+
 const TITLE_KEYS = ["Title", "Name"] as const;
 const DESCRIPTION_KEYS = ["Description", "Summary", "Excerpt"] as const;
 const SLUG_KEYS = ["Slug"] as const;
@@ -201,14 +218,14 @@ const resolveRelationNames = (property: unknown): string[] => {
 };
 
 const slugify = (value: string): string => {
-	return value
+	const normalizedSlug = value
 		.normalize("NFKD")
 		.replaceAll(/[^\w\s-]/g, "")
 		.trim()
 		.toLowerCase()
-		.replaceAll(/[\s_-]+/g, "-")
-		.replace(/^-+/, "")
-		.replace(/-+$/, "");
+		.replaceAll(/[\s_-]+/g, "-");
+
+	return trimHyphenEdges(normalizedSlug);
 };
 
 const normalizeNotionId = (value: string): string => {
@@ -238,13 +255,13 @@ const normalizeLocale = (value: string | undefined): Lang => {
 	}
 
 	const normalized = value.toLowerCase();
-	if (normalized in LOCALES) {
-		return normalized as Lang;
+	if (isLocale(normalized)) {
+		return normalized;
 	}
 
 	const base = normalized.split("-")[0];
-	if (base in LOCALES) {
-		return base as Lang;
+	if (isLocale(base)) {
+		return base;
 	}
 
 	return DEFAULT_LOCALE;

--- a/apps/blog/src/lib/notion/notion-loader.ts
+++ b/apps/blog/src/lib/notion/notion-loader.ts
@@ -40,7 +40,7 @@ type NotionLoaderOptions = {
 	sorts?: unknown[];
 	filter?: unknown;
 	archived?: boolean;
-	rehypePlugins?: ReadonlyArray<unknown>;
+	rehypePlugins?: ReadonlyArray<RehypePluginConfig>;
 };
 
 type NotionEntryData = {
@@ -93,7 +93,7 @@ const normalizeUrlValue = (value: unknown): string | undefined => {
 	return undefined;
 };
 
-type RehypePlugin = (tree: unknown, file: unknown) => void;
+type RehypePlugin = (...args: unknown[]) => unknown;
 
 type NotionModuleBlocks = {
 	isFullBlock: (value: unknown) => boolean;
@@ -149,6 +149,24 @@ type RehypePluginConfig =
 	| RehypePlugin
 	| string
 	| readonly [RehypePlugin, unknown];
+
+const isRehypePluginTupleConfig = (
+	config: RehypePluginConfig,
+): config is readonly [RehypePlugin, unknown] => Array.isArray(config);
+
+const isNotionEntryData = (value: unknown): value is NotionEntryData => {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+
+	const record = value as Record<string, unknown>;
+	return (
+		"cover" in record &&
+		"properties" in record &&
+		typeof record.properties === "object" &&
+		record.properties !== null
+	);
+};
 
 const ensureElementProperties = (node: ElementNode) => {
 	if (!node.properties) {
@@ -504,21 +522,24 @@ const createNotionLoaderNoImages = ({
 	rehypePlugins = [],
 	...clientOptions
 }: NotionLoaderOptions): Loader => {
-	const resolvedRehypePlugins = Promise.all(
-		rehypePlugins.map(async (config) => {
-			let plugin: unknown;
-			let options: unknown;
-			if (Array.isArray(config)) {
-				[plugin, options] = config;
-			} else {
-				plugin = config;
-			}
-			if (typeof plugin === "string") {
-				plugin = (await import(/* @vite-ignore */ plugin)).default;
-			}
-			return [plugin, options] as const;
-		}),
-	);
+	const resolvedRehypePlugins: Promise<ReadonlyArray<RehypePluginConfig>> =
+		Promise.all(
+			rehypePlugins.map(async (config) => {
+				let plugin: RehypePlugin | string;
+				let options: unknown;
+				if (isRehypePluginTupleConfig(config)) {
+					[plugin, options] = config;
+				} else {
+					plugin = config;
+				}
+				if (typeof plugin === "string") {
+					plugin = (await import(/* @vite-ignore */ plugin))
+						.default as RehypePlugin;
+				}
+
+				return options === undefined ? plugin : ([plugin, options] as const);
+			}),
+		);
 	const shouldRender = process.env.NOTION_LOADER_RENDER !== "0";
 
 	return {
@@ -688,19 +709,20 @@ const mapEntries = async (
 	context.store.clear();
 
 	for (const [sourceId, entry] of rawEntries) {
-		const mapped = mapNotionArticleEntry(
-			entry.data as NotionEntryData,
-			sourceId,
-			{
-				logger: context.logger,
-				platformId: options.platformId,
-				requiredType: options.requiredType,
-				requiredStatus: options.requiredStatus,
-				defaultAuthorId: options.defaultAuthorId,
-				defaultCategoryId: options.defaultCategoryId,
-				defaultTags: options.defaultTags,
-			},
-		);
+		if (!isNotionEntryData(entry.data)) {
+			context.logger.warn(`Skipping malformed Notion entry: ${sourceId}`);
+			continue;
+		}
+
+		const mapped = mapNotionArticleEntry(entry.data, sourceId, {
+			logger: context.logger,
+			platformId: options.platformId,
+			requiredType: options.requiredType,
+			requiredStatus: options.requiredStatus,
+			defaultAuthorId: options.defaultAuthorId,
+			defaultCategoryId: options.defaultCategoryId,
+			defaultTags: options.defaultTags,
+		});
 		if (!mapped) {
 			continue;
 		}

--- a/apps/blog/src/lib/notion/notion-loader.ts
+++ b/apps/blog/src/lib/notion/notion-loader.ts
@@ -43,6 +43,11 @@ type NotionLoaderOptions = {
 	rehypePlugins?: ReadonlyArray<unknown>;
 };
 
+type NotionEntryData = {
+	properties: Record<string, unknown>;
+	cover: unknown;
+};
+
 type CachedEntry = {
 	id: string;
 	data: NotionArticleData;
@@ -140,7 +145,10 @@ const applyPlugin = (
 		: typedProcessor.use(typedPlugin, options);
 };
 
-type RehypePluginConfig = unknown | string | readonly [unknown, unknown];
+type RehypePluginConfig =
+	| RehypePlugin
+	| string
+	| readonly [RehypePlugin, unknown];
 
 const ensureElementProperties = (node: ElementNode) => {
 	if (!node.properties) {
@@ -681,10 +689,7 @@ const mapEntries = async (
 
 	for (const [sourceId, entry] of rawEntries) {
 		const mapped = mapNotionArticleEntry(
-			entry.data as {
-				properties: Record<string, unknown>;
-				cover: unknown | null;
-			},
+			entry.data as NotionEntryData,
 			sourceId,
 			{
 				logger: context.logger,

--- a/apps/blog/tests/unit/content.config.test.ts
+++ b/apps/blog/tests/unit/content.config.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const importContentConfig = async () => {
+	vi.resetModules();
+	vi.doMock("astro/loaders", () => ({
+		glob: (config: Record<string, unknown>) => ({ type: "glob", ...config }),
+	}));
+	vi.doMock("astro:content", async () => {
+		const { z } = await import("astro/zod");
+		return {
+			defineCollection: (config: Record<string, unknown>) => config,
+			reference: () => z.string(),
+		};
+	});
+
+	return import("../../src/content.config");
+};
+
+describe("content.config", () => {
+	beforeEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.doUnmock("astro/loaders");
+		vi.doUnmock("astro:content");
+	});
+
+	it("uses the empty notion loader when NOTION_LOADER is disabled", async () => {
+		const { collections } = await importContentConfig();
+
+		await expect(collections.notionArticles.loader()).resolves.toEqual([]);
+	});
+
+	it("builds the notion loader with normalized ids when NOTION_LOADER is enabled", async () => {
+		vi.stubEnv("NOTION_LOADER", "1");
+		vi.stubEnv("NOTION_TOKEN", "token");
+		vi.stubEnv("NOTION_DATABASE_ID", "12345678-1234-1234-1234-1234567890ab");
+		vi.stubEnv("NOTION_PLATFORM_ID", "87654321-4321-4321-4321-ba0987654321");
+		vi.stubEnv("NOTION_DEFAULT_TAG_IDS", " en/tech, es/frontend ");
+
+		const { collections } = await importContentConfig();
+
+		expect(collections.notionArticles.loader).toMatchObject({
+			name: "notion-articles-loader",
+		});
+	});
+
+	it("parses the main collection schemas and applies defaults", async () => {
+		const { z } = await import("astro/zod");
+		const { collections } = await importContentConfig();
+
+		const image = () => z.string();
+		const resumeParsed = collections.resume.schema.parse({
+			basics: {
+				name: "Yuniel Acosta",
+				label: "Fullstack",
+				image: "/avatar.png",
+				email: "yuniel@example.com",
+				summary: "Resumen",
+				location: {
+					city: "Havana",
+					countryCode: "CU",
+					region: "La Habana",
+				},
+				profiles: [
+					{
+						network: "GitHub",
+						username: "yacosta738",
+						url: "https://github.com/yacosta738",
+					},
+				],
+			},
+			work: [
+				{
+					name: "YAP",
+					position: "Engineer",
+					startDate: "2024-01-01",
+					endDate: "",
+				},
+			],
+			volunteer: [
+				{
+					organization: "OSS",
+					position: "Maintainer",
+					startDate: "2023-01-01",
+					endDate: undefined,
+				},
+			],
+			education: [
+				{
+					institution: "CUJAE",
+					area: "CS",
+					studyType: "Bachelor",
+					startDate: "2010-01-01",
+					endDate: null,
+				},
+			],
+			skills: [{ name: "TypeScript" }],
+			projects: [
+				{
+					name: "Portfolio",
+					startDate: "",
+					endDate: "",
+				},
+			],
+		});
+
+		expect(resumeParsed.work[0]?.endDate).toBeNull();
+		expect(resumeParsed.volunteer?.[0]?.endDate).toBeNull();
+		expect(resumeParsed.education[0]?.endDate).toBeNull();
+		expect(resumeParsed.projects?.[0]?.startDate).toBeUndefined();
+		expect(resumeParsed.projects?.[0]?.endDate).toBeNull();
+
+		const articleSchema = collections.articles.schema({ image });
+		const articleParsed = articleSchema.parse({
+			title: "Hello",
+			description: "World",
+			date: "2026-01-01",
+			cover: "/cover.png",
+			author: "en/yuniel-acosta-perez",
+			tags: ["en/tech"],
+			category: "en/software-development",
+		});
+		expect(articleParsed.draft).toBe(false);
+		expect(articleParsed.featured).toBe(false);
+
+		const notionParsed = collections.notionArticles.schema.parse({
+			title: "Hello",
+			description: "World",
+			date: "2026-01-01",
+			author: "en/yuniel-acosta-perez",
+			tags: ["en/tech"],
+			category: "en/software-development",
+		});
+		expect(notionParsed.draft).toBe(false);
+		expect(notionParsed.featured).toBe(false);
+
+		const projectMetadataParsed = collections.projectMetadata.schema.parse({
+			title: "Portfolio",
+			date: "2026-01-01T00:00:00.000Z",
+			company: "YAP",
+		});
+		expect(projectMetadataParsed.showInProjects).toBe(false);
+		expect(projectMetadataParsed.featured).toBe(false);
+		expect(projectMetadataParsed.priority).toBe(0);
+		expect(projectMetadataParsed.published).toBe(false);
+
+		const externalArticleSchema = collections.externalArticles.schema({
+			image,
+		});
+		const externalArticleParsed = externalArticleSchema.parse({
+			title: "External",
+			description: "Article",
+			date: "2026-01-01",
+			cover: "/cover.png",
+			author: "en/yuniel-acosta-perez",
+			tags: ["en/tech"],
+			category: "en/software-development",
+			link: "https://example.com/post",
+		});
+		expect(externalArticleParsed.isExternal).toBe(true);
+
+		const authorParsed = collections.authors.schema.parse({
+			name: "Yuniel",
+			email: "yuniel@example.com",
+			avatar: "/avatar.png",
+			bio: "Bio",
+			location: "Havana",
+			socials: [
+				{
+					name: "GitHub",
+					url: "https://github.com/yacosta738",
+					icon: "github",
+				},
+			],
+		});
+		expect(authorParsed.socials).toHaveLength(1);
+	});
+});

--- a/apps/blog/tests/unit/lib/notion/notion-client.mock.ts
+++ b/apps/blog/tests/unit/lib/notion/notion-client.mock.ts
@@ -1,0 +1,27 @@
+type MockPage = Record<string, unknown>;
+
+declare global {
+	var __notionImportError: string | undefined;
+	var __notionPages: MockPage[] | undefined;
+}
+
+export class Client {
+	constructor() {
+		if (globalThis.__notionImportError) {
+			throw new Error(globalThis.__notionImportError);
+		}
+	}
+
+	databases = {
+		query: async () => ({ results: globalThis.__notionPages ?? [] }),
+	};
+	blocks = { children: { list: async () => ({ results: [] }) } };
+}
+
+export const isFullPage = () => true;
+export const isFullBlock = () => true;
+export const iteratePaginatedAPI = async function* () {
+	for (const page of globalThis.__notionPages ?? []) {
+		yield page;
+	}
+};

--- a/apps/blog/tests/unit/lib/notion/notion-loader.live.test.ts
+++ b/apps/blog/tests/unit/lib/notion/notion-loader.live.test.ts
@@ -1,0 +1,250 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@notionhq/client", async () => import("./notion-client.mock"));
+
+type StoreEntry = { id: string } & Record<string, unknown>;
+
+const createStore = () => {
+	const map = new Map<string, StoreEntry>();
+	return {
+		keys: () => map.keys(),
+		entries: () => Array.from(map.entries()),
+		get: (id: string) => map.get(id),
+		set: (entry: { id: string }) => {
+			map.set(entry.id, entry);
+		},
+		delete: (id: string) => map.delete(id),
+		clear: () => map.clear(),
+		count: () => map.size,
+	};
+};
+
+const createLogger = () => {
+	const logger = {
+		info: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+		fork: () => logger,
+	};
+	return logger;
+};
+
+const createContext = (
+	store: ReturnType<typeof createStore>,
+	logger: ReturnType<typeof createLogger>,
+) => ({
+	store,
+	logger,
+	parseData: async ({ data }: { data: unknown }) => data,
+	generateDigest: () => "digest",
+});
+
+const textFragments = (value: string) => [
+	{
+		type: "text",
+		text: { content: value, link: null },
+		annotations: {
+			bold: false,
+			italic: false,
+			strikethrough: false,
+			underline: false,
+			code: false,
+			color: "default",
+		},
+		plain_text: value,
+		href: null,
+	},
+];
+
+const titleProperty = (value: string) => ({
+	type: "title",
+	id: "title",
+	title: textFragments(value),
+});
+
+const richTextProperty = (value: string) => ({
+	type: "rich_text",
+	id: "rich",
+	rich_text: textFragments(value),
+});
+
+const dateProperty = (value: string) => ({
+	type: "date",
+	id: "date",
+	date: { start: value, end: null, time_zone: null },
+});
+
+const selectProperty = (value: string) => ({
+	type: "select",
+	id: "select",
+	select: { id: "value", name: value, color: "blue" },
+});
+
+const relationProperty = (values: Array<{ id: string; name?: string }>) => ({
+	type: "relation",
+	id: "relation",
+	relation: values,
+});
+
+const checkboxProperty = (value: boolean) => ({
+	type: "checkbox",
+	id: "checkbox",
+	checkbox: value,
+});
+
+const statusProperty = (value: string) => ({
+	type: "status",
+	id: "status",
+	status: { id: "status", name: value, color: "green" },
+});
+
+const createLivePage = (platformId: string) => ({
+	id: "page-1",
+	last_edited_time: "2024-01-05T00:00:00.000Z",
+	cover: null,
+	properties: {
+		Name: titleProperty("Hello World"),
+		Description: richTextProperty("First post"),
+		"Schedule Date": dateProperty("2024-01-02"),
+		Author: richTextProperty("Yuniel Acosta"),
+		Platforms: relationProperty([{ id: platformId }]),
+		Type: selectProperty("Article"),
+		Status: statusProperty("Ready"),
+		Published: checkboxProperty(true),
+	},
+});
+
+const importLoader = async () => {
+	vi.resetModules();
+	return import("@blog/lib/notion/notion-loader");
+};
+
+afterEach(() => {
+	delete globalThis.__notionImportError;
+	delete globalThis.__notionPages;
+	vi.unstubAllEnvs();
+	vi.resetModules();
+});
+
+describe("createCachedNotionLoader live sync", () => {
+	it("maps live Notion pages and writes the cache on success", async () => {
+		vi.stubEnv("NOTION_LOADER_RENDER", "0");
+		const platformId = "ea2cff95e1ca82ab97128153e241fe9a";
+		globalThis.__notionPages = [createLivePage(platformId)];
+
+		const { createCachedNotionLoader } = await importLoader();
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "notion-live-"));
+		const cacheUrl = new URL("live-cache.json", pathToFileURL(`${tempDir}/`));
+		const loader = createCachedNotionLoader({
+			auth: "token",
+			database_id: "db",
+			cacheUrl,
+			platformId,
+			requiredType: "Article",
+			requiredStatus: "Ready",
+			defaultAuthorId: "en/yuniel-acosta-perez",
+			defaultCategoryId: "en/software-development",
+			defaultTags: ["en/tech"],
+		});
+		const store = createStore();
+		const logger = createLogger();
+		const context = createContext(store, logger);
+
+		await loader.load(context);
+
+		expect(store.count()).toBe(1);
+		const cache = JSON.parse(await readFile(cacheUrl, "utf-8")) as {
+			entries: Array<{ id: string; sourceId: string; data: { title: string } }>;
+		};
+		expect(cache.entries).toHaveLength(1);
+		expect(cache.entries[0]).toMatchObject({
+			sourceId: "page-1",
+			data: { title: "Hello World" },
+		});
+
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("skips mapping when NOTION_LOADER_SKIP_MAP is enabled", async () => {
+		vi.stubEnv("NOTION_LOADER_RENDER", "0");
+		vi.stubEnv("NOTION_LOADER_SKIP_MAP", "1");
+		const platformId = "ea2cff95e1ca82ab97128153e241fe9a";
+		globalThis.__notionPages = [createLivePage(platformId)];
+
+		const { createCachedNotionLoader } = await importLoader();
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "notion-skip-map-"));
+		const cacheUrl = new URL(
+			"skip-map-cache.json",
+			pathToFileURL(`${tempDir}/`),
+		);
+		const loader = createCachedNotionLoader({
+			auth: "token",
+			database_id: "db",
+			cacheUrl,
+			platformId,
+		});
+		const store = createStore();
+		const logger = createLogger();
+		const context = createContext(store, logger);
+
+		await loader.load(context);
+
+		expect(store.get("page-1")).toBeDefined();
+		expect(store.get("en/2024/01/02/hello-world")).toBeUndefined();
+
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("emits a targeted warning for invalid tokens", async () => {
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "notion-errors-"));
+		const baseUrl = pathToFileURL(`${tempDir}/`);
+		globalThis.__notionImportError = "api token is invalid";
+
+		const { createCachedNotionLoader } = await importLoader();
+		const loader = createCachedNotionLoader({
+			auth: "token",
+			database_id: "db",
+			cacheUrl: new URL("invalid-token.json", baseUrl),
+		});
+		const store = createStore();
+		const logger = createLogger();
+		const context = createContext(store, logger);
+
+		await loader.load(context);
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			"Notion token rejected. Check NOTION_TOKEN in build env and re-share the database with the integration.",
+		);
+
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("emits a targeted warning for missing databases", async () => {
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "notion-errors-"));
+		const baseUrl = pathToFileURL(`${tempDir}/`);
+		globalThis.__notionImportError = "object not found";
+
+		const { createCachedNotionLoader } = await importLoader();
+		const loader = createCachedNotionLoader({
+			auth: "token",
+			database_id: "db",
+			cacheUrl: new URL("missing-database.json", baseUrl),
+		});
+		const store = createStore();
+		const logger = createLogger();
+		const context = createContext(store, logger);
+
+		await loader.load(context);
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			"Notion database not found or not shared. Verify NOTION_DATABASE_ID and ensure the integration has access.",
+		);
+
+		await rm(tempDir, { recursive: true, force: true });
+	});
+});

--- a/apps/blog/tests/unit/lib/notion/notion-loader.test.ts
+++ b/apps/blog/tests/unit/lib/notion/notion-loader.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createCachedNotionLoader } from "@blog/lib/notion/notion-loader";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 type StoreEntry = { id: string } & Record<string, unknown>;
 
@@ -43,6 +43,10 @@ const createContext = (
 		generateDigest: () => "digest",
 	};
 };
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
 
 describe("createCachedNotionLoader", () => {
 	it("uses cached entries when Notion credentials are missing", async () => {
@@ -118,6 +122,94 @@ describe("createCachedNotionLoader", () => {
 		expect(store.count()).toBe(0);
 		expect(logger.warn).toHaveBeenCalledWith(
 			expect.stringContaining("No Notion cache found"),
+		);
+
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("falls back to cache when the live loader fails", async () => {
+		vi.stubEnv("NOTION_LOADER_TRACE", "pre-query");
+
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "notion-cache-"));
+		const cacheUrl = new URL(
+			"fallback-cache.json",
+			pathToFileURL(`${tempDir}/`),
+		);
+		await writeFile(
+			cacheUrl,
+			JSON.stringify(
+				{
+					version: 1,
+					databaseId: "db",
+					lastSync: new Date().toISOString(),
+					entries: [
+						{
+							id: "en/2026/03/11/fallback",
+							data: {
+								title: "Fallback entry",
+								description: "Recovered from cache",
+								date: "2026-03-11T00:00:00.000Z",
+								author: "en/yuniel-acosta-perez",
+								tags: ["en/tech"],
+								category: "en/software-development",
+							},
+							digest: "digest",
+						},
+					],
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		const loader = createCachedNotionLoader({
+			auth: "token",
+			database_id: "db",
+			cacheUrl,
+		});
+		const store = createStore();
+		const logger = createLogger();
+		const context = createContext(store, logger);
+
+		await loader.load(context);
+
+		expect(store.count()).toBe(1);
+		expect(store.get("en/2026/03/11/fallback")).toBeDefined();
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Notion loader failed; attempting cache fallback.",
+			),
+		);
+
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("warns when a live loader failure has no cache fallback", async () => {
+		vi.stubEnv("NOTION_LOADER_TRACE", "pre-query");
+
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "notion-cache-"));
+		const cacheUrl = new URL(
+			"missing-fallback-cache.json",
+			pathToFileURL(`${tempDir}/`),
+		);
+
+		const loader = createCachedNotionLoader({
+			auth: "token",
+			database_id: "db",
+			cacheUrl,
+		});
+		const store = createStore();
+		const logger = createLogger();
+		const context = createContext(store, logger);
+
+		await loader.load(context);
+
+		expect(store.count()).toBe(0);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"No Notion cache found; continuing without Notion entries.",
+			),
 		);
 
 		await rm(tempDir, { recursive: true, force: true });

--- a/packages/notion-astro-loader/src/loader.ts
+++ b/packages/notion-astro-loader/src/loader.ts
@@ -171,9 +171,10 @@ export function notionLoader({
 
 				const isCached = existingPageIds.delete(page.id);
 				const existingPage = store.get(page.id);
+				const pageIsUnchanged = existingPage?.digest === page.last_edited_time;
 
 				// If the page has been updated, re-render it
-				if (existingPage?.digest !== page.last_edited_time) {
+				if (!pageIsUnchanged) {
 					const realSavePath = path.resolve(
 						process.cwd(),
 						"src",

--- a/packages/notion-astro-loader/src/loader.ts
+++ b/packages/notion-astro-loader/src/loader.ts
@@ -171,10 +171,9 @@ export function notionLoader({
 
 				const isCached = existingPageIds.delete(page.id);
 				const existingPage = store.get(page.id);
-				const pageIsUnchanged = existingPage?.digest === page.last_edited_time;
 
 				// If the page has been updated, re-render it
-				if (!pageIsUnchanged) {
+				if (existingPage?.digest !== page.last_edited_time) {
 					const realSavePath = path.resolve(
 						process.cwd(),
 						"src",

--- a/packages/shared/src/core/tag/tag.mapper.test.ts
+++ b/packages/shared/src/core/tag/tag.mapper.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { toTag } from "./tag.mapper";
+
+describe("toTag", () => {
+	it("builds a slug from the title without leading or trailing dashes", () => {
+		const tag = toTag({
+			id: "en/tags/clean-code",
+			data: {
+				title: " --- Clean   Code --- ",
+			},
+		} as never);
+
+		expect(tag.slug).toBe("clean-code");
+		expect(tag.title).toBe("--- Clean   Code ---");
+	});
+
+	it("falls back to the entity slug when the normalized title becomes empty", () => {
+		const tag = toTag({
+			id: "en/tags/c-plus-plus",
+			data: {
+				title: "!!!",
+			},
+		} as never);
+
+		expect(tag.slug).toBe("c-plus-plus");
+	});
+});

--- a/packages/shared/src/core/tag/tag.mapper.ts
+++ b/packages/shared/src/core/tag/tag.mapper.ts
@@ -7,6 +7,21 @@ import type { CollectionEntry } from "astro:content";
 import { cleanEntityId } from "@/lib/collection.entity";
 import type Tag from "./tag.model";
 
+const trimHyphenEdges = (value: string): string => {
+	let start = 0;
+	let end = value.length;
+
+	while (start < end && value[start] === "-") {
+		start += 1;
+	}
+
+	while (end > start && value[end - 1] === "-") {
+		end -= 1;
+	}
+
+	return value.slice(start, end);
+};
+
 /**
  * Converts a single tag collection entry to a Tag object
  * @param {CollectionEntry<"tags">} tagData - The tag collection entry to convert
@@ -31,14 +46,13 @@ export function toTag(tagData: CollectionEntry<"tags">): Tag {
 		// Use split-join pattern instead of regex with + to prevent potential ReDoS
 		.split(/[^a-z0-9]+/)
 		.filter(Boolean)
-		.join("-")
-		// Remove leading/trailing dashes with separate anchored replacements (no alternation = no backtracking)
-		.replace(/^-+/, "")
-		.replace(/-+$/, "");
+		.join("-");
+
+	const normalizedSlug = trimHyphenEdges(slugFromTitle);
 
 	let slug = fallbackSlug;
-	if (slugFromTitle.length > 0) {
-		slug = slugFromTitle;
+	if (normalizedSlug.length > 0) {
+		slug = normalizedSlug;
 	}
 
 	return {

--- a/packages/shared/src/i18n/i18n.test.ts
+++ b/packages/shared/src/i18n/i18n.test.ts
@@ -1,4 +1,12 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 
 const mockShowDefaultLang = vi.fn().mockReturnValue(false);
 const mockExtractTagSlugFromPath = vi.fn();
@@ -52,6 +60,10 @@ describe("shared i18n helpers", () => {
 		mockGetTagLocalePaths.mockReset();
 		mockIsTagPage.mockReset();
 		vi.stubEnv("LANG", "es");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
 	});
 
 	it("builds translated paths for target languages", () => {

--- a/packages/shared/src/i18n/i18n.test.ts
+++ b/packages/shared/src/i18n/i18n.test.ts
@@ -1,0 +1,115 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockShowDefaultLang = vi.fn().mockReturnValue(false);
+const mockExtractTagSlugFromPath = vi.fn();
+const mockGetTagLocalePaths = vi.fn();
+const mockIsTagPage = vi.fn();
+
+vi.mock("@/core/tag", () => ({
+	extractTagSlugFromPath: mockExtractTagSlugFromPath,
+	getTagLocalePaths: mockGetTagLocalePaths,
+	isTagPage: mockIsTagPage,
+}));
+
+vi.mock("./types", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./types")>();
+	return {
+		...actual,
+		get SHOW_DEFAULT_LANG_IN_URL() {
+			return mockShowDefaultLang();
+		},
+	};
+});
+
+vi.mock("astro:i18n", () => ({
+	getRelativeLocaleUrl: vi.fn((lang: string, path: string) =>
+		lang === "en" ? path : `/${lang}${path}`,
+	),
+}));
+
+let getLocalePaths: typeof import("./i18n")["getLocalePaths"];
+let getLocalePathsEnhanced: typeof import("./i18n")["getLocalePathsEnhanced"];
+let localeParams: typeof import("./i18n")["localeParams"];
+let localeRouteParams: typeof import("./i18n")["localeRouteParams"];
+let retrieveLocalizedString: typeof import("./i18n")["retrieveLocalizedString"];
+let useTranslatedPath: typeof import("./i18n")["useTranslatedPath"];
+
+beforeAll(async () => {
+	const mod = await import("./i18n");
+	getLocalePaths = mod.getLocalePaths;
+	getLocalePathsEnhanced = mod.getLocalePathsEnhanced;
+	localeParams = mod.localeParams;
+	localeRouteParams = mod.localeRouteParams;
+	retrieveLocalizedString = mod.retrieveLocalizedString;
+	useTranslatedPath = mod.useTranslatedPath;
+});
+
+describe("shared i18n helpers", () => {
+	beforeEach(() => {
+		mockShowDefaultLang.mockReset();
+		mockShowDefaultLang.mockReturnValue(false);
+		mockExtractTagSlugFromPath.mockReset();
+		mockGetTagLocalePaths.mockReset();
+		mockIsTagPage.mockReset();
+		vi.stubEnv("LANG", "es");
+	});
+
+	it("builds translated paths for target languages", () => {
+		const translatePath = useTranslatedPath("en");
+
+		expect(translatePath("/about", "es")).toBe("/es/about");
+		expect(translatePath("/es/about", "en")).toBe("/about");
+	});
+
+	it("returns locale paths for all languages", () => {
+		const paths = getLocalePaths(new URL("https://example.com/en/about"));
+
+		expect(paths).toEqual([
+			{ lang: "en", path: "/about" },
+			{ lang: "es", path: "/es/about" },
+		]);
+	});
+
+	it("uses tag-aware paths for tag pages", async () => {
+		mockIsTagPage.mockReturnValue(true);
+		mockExtractTagSlugFromPath.mockReturnValue("security");
+		mockGetTagLocalePaths.mockResolvedValue([
+			{ lang: "en", path: "/tag/security", tagFound: true },
+			{ lang: "es", path: { path: "/es/tag/seguridad" }, tagFound: true },
+		]);
+
+		const paths = await getLocalePathsEnhanced(
+			new URL("https://example.com/en/tag/security"),
+		);
+
+		expect(paths).toEqual([
+			{ lang: "en", path: "/tag/security" },
+			{ lang: "es", path: "/es/tag/seguridad" },
+		]);
+	});
+
+	it("falls back to the standard locale paths for non-tag pages", async () => {
+		mockIsTagPage.mockReturnValue(false);
+
+		const paths = await getLocalePathsEnhanced(
+			new URL("https://example.com/en/about"),
+		);
+
+		expect(paths).toEqual([
+			{ lang: "en", path: "/about" },
+			{ lang: "es", path: "/es/about" },
+		]);
+	});
+
+	it("exposes locale params based on the configured locales", () => {
+		expect(localeParams).toEqual([
+			{ params: { lang: "en" } },
+			{ params: { lang: "es" } },
+		]);
+		expect(localeRouteParams).toEqual([{ params: { lang: "es" } }]);
+	});
+
+	it("retrieves localized strings using the current environment language", () => {
+		expect(retrieveLocalizedString({ en: "Hello", es: "Hola" })).toBe("Hola");
+	});
+});

--- a/packages/shared/src/i18n/i18n.ts
+++ b/packages/shared/src/i18n/i18n.ts
@@ -157,7 +157,9 @@ export const localeParams = Object.keys(LOCALES).map((lang) => ({
 	params: { lang },
 }));
 
-const ROUTE_LOCALE_KEYS = Object.keys(LOCALES) as Lang[];
+const ROUTE_LOCALE_KEYS = Object.keys(LOCALES).filter(
+	(lang): lang is Lang => lang in LOCALES,
+);
 
 export const ROUTE_LOCALES: Lang[] = SHOW_DEFAULT_LANG_IN_URL
 	? ROUTE_LOCALE_KEYS

--- a/packages/shared/src/i18n/types.test.ts
+++ b/packages/shared/src/i18n/types.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isLang } from "./types";
+import { resolveLocaleFromUrl } from "./utils/resolveLocaleFromUrl";
+
+describe("isLang", () => {
+	it("accepts configured locale keys only", () => {
+		expect(isLang("en")).toBe(true);
+		expect(isLang("es")).toBe(true);
+		expect(isLang("fr")).toBe(false);
+	});
+
+	it("rejects inherited prototype keys", () => {
+		expect(isLang("__proto__")).toBe(false);
+		expect(isLang("constructor")).toBe(false);
+		expect(isLang("toString")).toBe(false);
+	});
+});
+
+describe("resolveLocaleFromUrl", () => {
+	it("prefers a valid params language", () => {
+		const locale = resolveLocaleFromUrl(
+			new URL("https://example.com/es/about"),
+			"en",
+		);
+
+		expect(locale).toBe("en");
+	});
+
+	it("falls back to a valid locale in the path", () => {
+		const locale = resolveLocaleFromUrl(
+			new URL("https://example.com/es/about"),
+		);
+
+		expect(locale).toBe("es");
+	});
+
+	it("falls back to the default locale for invalid inputs", () => {
+		expect(
+			resolveLocaleFromUrl(new URL("https://example.com/about"), "fr"),
+		).toBe("en");
+		expect(
+			resolveLocaleFromUrl(new URL("https://example.com/__proto__/about")),
+		).toBe("en");
+	});
+});

--- a/packages/shared/src/i18n/types.ts
+++ b/packages/shared/src/i18n/types.ts
@@ -25,7 +25,8 @@ export type Translations = Record<string, Record<string, string>>;
  */
 export type Lang = keyof typeof LOCALES;
 
-export const isLang = (value: string): value is Lang => value in LOCALES;
+export const isLang = (value: string): value is Lang =>
+	Object.hasOwn(LOCALES, value);
 
 export const DEFAULT_LOCALE: Lang = DEFAULT_LOCALE_SETTING;
 

--- a/packages/shared/src/i18n/types.ts
+++ b/packages/shared/src/i18n/types.ts
@@ -25,6 +25,8 @@ export type Translations = Record<string, Record<string, string>>;
  */
 export type Lang = keyof typeof LOCALES;
 
+export const isLang = (value: string): value is Lang => value in LOCALES;
+
 export const DEFAULT_LOCALE: Lang = DEFAULT_LOCALE_SETTING;
 
 /**

--- a/packages/shared/src/i18n/ui.test.ts
+++ b/packages/shared/src/i18n/ui.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("ui translations", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env.NODE_ENV;
+	});
+
+	it("loads and merges translation files for supported languages", async () => {
+		const { ui } = await import("./ui");
+
+		expect(Object.keys(ui.en).length).toBeGreaterThan(0);
+		expect(Object.keys(ui.es).length).toBeGreaterThan(0);
+	});
+
+	it("logs translation counts in development mode", async () => {
+		vi.resetModules();
+		process.env.NODE_ENV = "development";
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		await import("./ui");
+
+		expect(logSpy).toHaveBeenCalledWith(
+			"㊙︎ Loaded translations:",
+			expect.stringContaining("en:"),
+		);
+	});
+});

--- a/packages/shared/src/i18n/ui.test.ts
+++ b/packages/shared/src/i18n/ui.test.ts
@@ -1,9 +1,19 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let previousNodeEnv: string | undefined;
 
 describe("ui translations", () => {
+	beforeEach(() => {
+		previousNodeEnv = process.env.NODE_ENV;
+	});
+
 	afterEach(() => {
 		vi.restoreAllMocks();
-		delete process.env.NODE_ENV;
+		if (previousNodeEnv === undefined) {
+			delete process.env.NODE_ENV;
+		} else {
+			process.env.NODE_ENV = previousNodeEnv;
+		}
 	});
 
 	it("loads and merges translation files for supported languages", async () => {

--- a/packages/shared/src/i18n/ui.ts
+++ b/packages/shared/src/i18n/ui.ts
@@ -1,4 +1,4 @@
-import type { Lang, UIDict, UIMultilingual } from "./types";
+import { isLang, type Lang, type UIDict, type UIMultilingual } from "./types";
 
 // Use import.meta.glob to get all translation files
 const translationModules = import.meta.glob<
@@ -28,10 +28,10 @@ export const ui: UIMultilingual = Object.values(translationModules).reduce(
 
 		// For each language in the export
 		for (const [lang, translations] of Object.entries(translationExport)) {
-			if (lang in acc) {
+			if (isLang(lang)) {
 				// Merge translations into the accumulated object
-				acc[lang as Lang] = {
-					...acc[lang as Lang],
+				acc[lang] = {
+					...acc[lang],
 					...(translations as UIDict),
 				};
 			}

--- a/packages/shared/src/i18n/utils/resolveLocaleFromUrl.ts
+++ b/packages/shared/src/i18n/utils/resolveLocaleFromUrl.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LOCALE, type Lang, LOCALES } from "@/i18n";
+import { DEFAULT_LOCALE, isLang, type Lang } from "@/i18n";
 
 /**
  * Resolves the current locale from the URL and optional params.lang.
@@ -6,8 +6,13 @@ import { DEFAULT_LOCALE, type Lang, LOCALES } from "@/i18n";
  */
 export function resolveLocaleFromUrl(url: URL, paramsLang?: string): Lang {
 	const localeSegment = url.pathname.split("/")[1];
-	const validLocales = Object.keys(LOCALES);
-	return (paramsLang ||
-		(validLocales.includes(localeSegment) ? localeSegment : undefined) ||
-		DEFAULT_LOCALE) as Lang;
+	if (paramsLang && isLang(paramsLang)) {
+		return paramsLang;
+	}
+
+	if (localeSegment && isLang(localeSegment)) {
+		return localeSegment;
+	}
+
+	return DEFAULT_LOCALE;
 }

--- a/packages/shared/src/lib/seo/json-ld.test.ts
+++ b/packages/shared/src/lib/seo/json-ld.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildPersonJsonLd, safeJsonLd } from "./json-ld";
+
+describe("safeJsonLd", () => {
+	it("escapes angle brackets to prevent script breakouts", () => {
+		const serialized = safeJsonLd({
+			value: "</script><script>alert(1)</script>",
+		});
+
+		expect(serialized).not.toContain("</script>");
+		expect(serialized).toContain(String.raw`\u003c/script>`);
+	});
+});
+
+describe("buildPersonJsonLd", () => {
+	it("normalizes relative image urls against the site origin", () => {
+		const person = buildPersonJsonLd(
+			{
+				name: "Yuniel Acosta",
+				image: "/images/profile.webp",
+				profiles: [{ url: "https://github.com/yacosta738" }],
+			},
+			"https://example.com",
+		);
+
+		expect(person).toMatchObject({
+			"@type": "Person",
+			image: "https://example.com/images/profile.webp",
+			sameAs: ["https://github.com/yacosta738"],
+		});
+	});
+});

--- a/packages/shared/src/lib/seo/json-ld.ts
+++ b/packages/shared/src/lib/seo/json-ld.ts
@@ -4,7 +4,7 @@
 
 /** Safely serialize JSON-LD, escaping `<` to prevent `</script>` breakout */
 export const safeJsonLd = (data: Record<string, unknown>): string =>
-	JSON.stringify(data).replace(/</g, "\\u003c");
+	JSON.stringify(data).replaceAll("<", String.raw`\u003c`);
 
 /** Extract a URL string from an image that may be a string or ImageMetadata */
 const getImageUrl = (


### PR DESCRIPTION
## Summary
- improve SonarCloud analysis so packages coverage is included and config-file duplication does not fail the quality gate
- fix Sonar issues in i18n and Notion mapping logic, including safer locale guards and regex-free slug edge trimming
- add focused shared tests for JSON-LD escaping and tag slug normalization to raise coverage on new code

## Validation
- pnpm --filter=blog exec vitest run tests/unit/lib/notion/notion-article.mapper.test.ts tests/unit/lib/notion/notion-loader.test.ts tests/unit/i18n/__tests__/i18n.test.ts
- pnpm --filter=@portfolio/shared exec vitest run src/lib/seo/json-ld.test.ts src/core/tag/tag.mapper.test.ts
- pnpm exec biome check <changed-files>

## Notes
- the full `packages/shared` test suite still has pre-existing failures unrelated to this PR
- this PR adds targeted shared coverage in CI so Sonar can evaluate the fixed files correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale validation and URL resolution across i18n helpers
  * Deterministic trimming for tag slugs with better fallback behavior
  * Fixed JSON-LD serialization to escape HTML sequences for SEO
  * More robust external content loading/mapping to skip malformed entries

* **Tests**
  * Added comprehensive tests for i18n, tag slugging, SEO JSON-LD, and content loading

* **Chores**
  * Expanded CI coverage discovery and static-analysis configuration for multi-package scans
<!-- end of auto-generated comment: release notes by coderabbit.ai -->