### PR TITLE
fix: Resolve Notion images blocked by ORB in ArticleCard

### DIFF
--- a/apps/blog/src/lib/notion/notion-image.ts
+++ b/apps/blog/src/lib/notion/notion-image.ts
@@ -110,7 +110,10 @@ const deriveImagePaths = (
 export const downloadNotionImage = async (
 	url: string,
 	saveDir: string,
-	logger?: { debug: (message: string) => void },
+	logger?: {
+		debug: (message: string) => void;
+		warn?: (message: string) => void;
+	},
 ): Promise<string> => {
 	if (!isNotionS3Url(url)) {
 		return url;
@@ -119,7 +122,9 @@ export const downloadNotionImage = async (
 	const cleanUrl = decodeHtmlEntities(url);
 	const paths = deriveImagePaths(cleanUrl, saveDir);
 	if (!paths) {
-		logger?.debug(`notion-image: unable to parse S3 URL: ${cleanUrl}`);
+		(logger?.warn ?? logger?.debug)?.(
+			`notion-image: unable to parse S3 URL: ${cleanUrl}`,
+		);
 		return url;
 	}
 
@@ -135,14 +140,17 @@ export const downloadNotionImage = async (
 			signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
 		});
 		if (!response.ok) {
-			logger?.debug(
+			(logger?.warn ?? logger?.debug)?.(
 				`notion-image: download failed (${response.status}): ${cleanUrl}`,
 			);
 			return url;
 		}
 		const contentType = response.headers.get("content-type") ?? "";
-		if (!contentType.startsWith("image/")) {
-			logger?.debug(
+		if (
+			!contentType.startsWith("image/") &&
+			contentType !== "application/octet-stream"
+		) {
+			(logger?.warn ?? logger?.debug)?.(
 				`notion-image: unexpected content-type "${contentType}" for ${cleanUrl}`,
 			);
 			return url;
@@ -152,7 +160,7 @@ export const downloadNotionImage = async (
 		logger?.debug(`notion-image: downloaded ${paths.publicPath}`);
 		return paths.publicPath;
 	} catch (error) {
-		logger?.debug(
+		(logger?.warn ?? logger?.debug)?.(
 			`notion-image: download error: ${error instanceof Error ? error.message : String(error)}`,
 		);
 		return url;
@@ -166,7 +174,10 @@ export const downloadNotionImage = async (
 export const downloadImagesInHtml = async (
 	html: string,
 	saveDir: string,
-	logger?: { debug: (message: string) => void },
+	logger?: {
+		debug: (message: string) => void;
+		warn?: (message: string) => void;
+	},
 ): Promise<string> => {
 	const matches = [
 		...new Set(html.match(new RegExp(S3_URL_IN_HTML_SOURCE, "g")) ?? []),

--- a/apps/blog/src/lib/notion/notion-image.ts
+++ b/apps/blog/src/lib/notion/notion-image.ts
@@ -18,6 +18,9 @@ export const containsS3Url = (html: string): boolean =>
 const PUBLIC_SUBDIR = "images/notion";
 const DOWNLOAD_TIMEOUT_MS = 30_000;
 
+/** Strip query string and fragment from a URL for safe logging. */
+const redactUrl = (url: string): string => url.split("?")[0].split("#")[0];
+
 export const isNotionS3Url = (url: string): boolean => {
 	try {
 		const parsed = new URL(decodeHtmlEntities(url));
@@ -123,7 +126,7 @@ export const downloadNotionImage = async (
 	const paths = deriveImagePaths(cleanUrl, saveDir);
 	if (!paths) {
 		(logger?.warn ?? logger?.debug)?.(
-			`notion-image: unable to parse S3 URL: ${cleanUrl}`,
+			`notion-image: unable to parse S3 URL: ${redactUrl(cleanUrl)}`,
 		);
 		return url;
 	}
@@ -141,17 +144,18 @@ export const downloadNotionImage = async (
 		});
 		if (!response.ok) {
 			(logger?.warn ?? logger?.debug)?.(
-				`notion-image: download failed (${response.status}): ${cleanUrl}`,
+				`notion-image: download failed (${response.status}): ${redactUrl(cleanUrl)}`,
 			);
 			return url;
 		}
 		const contentType = response.headers.get("content-type") ?? "";
+		const mediaType = contentType.split(";")[0].trim().toLowerCase();
 		if (
-			!contentType.startsWith("image/") &&
-			contentType !== "application/octet-stream"
+			!mediaType.startsWith("image/") &&
+			mediaType !== "application/octet-stream"
 		) {
 			(logger?.warn ?? logger?.debug)?.(
-				`notion-image: unexpected content-type "${contentType}" for ${cleanUrl}`,
+				`notion-image: unexpected content-type "${contentType}" for ${redactUrl(cleanUrl)}`,
 			);
 			return url;
 		}

--- a/apps/blog/src/lib/notion/notion-loader.ts
+++ b/apps/blog/src/lib/notion/notion-loader.ts
@@ -114,7 +114,9 @@ type NotionModuleLoad = {
 	Client: new (
 		opts: unknown,
 	) => {
-		blocks: { children: { list: (args: Record<string, unknown>) => Promise<unknown> } };
+		blocks: {
+			children: { list: (args: Record<string, unknown>) => Promise<unknown> };
+		};
 	};
 	LogLevel?: {
 		ERROR?: string;

--- a/packages/shared/src/components/molecules/ArticleCard.astro
+++ b/packages/shared/src/components/molecules/ArticleCard.astro
@@ -49,23 +49,15 @@ const rel = isExternal
 		<span class="sr-only">{title}</span>
 		<div class="blog-article-card__media">
 			{
-				image &&
-					(typeof image === "string" ? (
-						<img
-							src={image}
-							alt={title}
-							loading={loading}
-							class="h-full w-full object-cover"
-						/>
-					) : (
-						<OptimizedPicture
-							src={image}
-							alt={title}
-							loading={loading}
-							inferSize
-							class="h-full w-full object-cover"
-						/>
-					))
+				image && (
+					<OptimizedPicture
+						src={image}
+						alt={title}
+						loading={loading}
+						inferSize
+						class="h-full w-full object-cover"
+					/>
+				)
 			}
 		</div>
 		<footer


### PR DESCRIPTION
## Summary

Notion S3 cover images on Spanish blog posts (`/es/`) were broken due to Chrome's ORB (Opaque Response Blocking) rejecting cross-origin S3 responses.

## Root Cause

Two issues combined to break images:

1. **`ArticleCard.astro`** used a raw `<img src={url}>` for string URLs (Notion S3 covers), bypassing Astro's image optimization. S3 responses lack CORS headers, triggering `ERR_BLOCKED_BY_ORB`.
2. **`notion-image.ts`** rejected valid S3 responses with `Content-Type: application/octet-stream` (common for uploaded files), silently falling back to the original S3 URL. Failures logged at `debug` level were invisible in CI.

## Changes

- **`ArticleCard.astro`**: Always use `OptimizedPicture` for cover images (both `ImageMetadata` and string URLs). Astro downloads and optimizes remote images at build time, serving them from `_astro/` (same origin, no ORB).
- **`notion-image.ts`**: Accept `application/octet-stream` content-type alongside `image/*`. Surface download failures at `warn` level for CI visibility.

## Validation

- Lint & type check: 0 errors, 0 warnings
- Unit tests: 274 passed (blog: 150, portfolio: 100, api: 24)
- Build: 531 pages generated successfully
- Notion images confirmed optimized to avif/webp in build output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Image downloads now accept additional content types for broader compatibility and fewer failures.
  * Upload/download error messages now use warning-level logs and redact URLs to improve privacy and surface important issues.

* **Refactor**
  * Simplified article card image rendering for more consistent behavior and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->