### PR TITLE
fix(seo): repair blog links and trailing slash normalization

### DIFF
--- a/packages/shared/src/components/molecules/WidgetRecentPost.astro
+++ b/packages/shared/src/components/molecules/WidgetRecentPost.astro
@@ -5,6 +5,7 @@ import { type Lang, useTranslations } from "@/i18n";
 import { LOCALES } from "@/i18n/types";
 import type { BlogPost } from "@/lib/blog-post.utils";
 import {
+	ensureSingleTrailingSlash,
 	getBlogPostRel,
 	getBlogPostTarget,
 	getBlogPostUrl,
@@ -55,12 +56,12 @@ const t = useTranslations(currentLocale);
 									name="mdi:chevron-right"
 									class="h-5 w-5 mr-1"
 								/>
-								<a
-									href={`${url}${isExternalArticle(post) ? "" : "/"}`}
-									class="inline-link flex items-center justify-center"
-									target={getBlogPostTarget(post)}
-									rel={getBlogPostRel(post)}
-								>
+							<a
+								href={isExternalArticle(post) ? url : ensureSingleTrailingSlash(url)}
+								class="inline-link flex items-center justify-center"
+								target={getBlogPostTarget(post)}
+								rel={getBlogPostRel(post)}
+							>
 									<p class="pl-2">{post.title}</p>
 								</a>
 							</div>

--- a/packages/shared/src/components/organisms/PostCard.astro
+++ b/packages/shared/src/components/organisms/PostCard.astro
@@ -4,8 +4,8 @@ import { routes } from "@/configs/route.path";
 import type Article from "@/core/article/article.model";
 import { getTagSlug } from "@/core/tag";
 import { type Lang, useTranslatedPath, useTranslations } from "@/i18n";
-import { cleanEntityId } from "@/lib/collection.entity";
 import { ensureSingleTrailingSlash } from "@/lib/blog-post.utils";
+import { cleanEntityId } from "@/lib/collection.entity";
 import { buildBlogUrl, getBlogBaseUrl } from "@/utils/blog-url";
 
 const currentLocale = Astro.currentLocale as Lang;
@@ -72,7 +72,9 @@ const contentLink = ensureSingleTrailingSlash(
 					<a
 						class="w-fit inline text-[9px] tracking-widest uppercase transition-colors hover:opacity-80 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none text-foreground-muted"
 						href={buildBlogHref(
-							translatePath(`/${routes.tag}/${getTagSlug(tag)}/`),
+							ensureSingleTrailingSlash(
+								translatePath(`/${routes.tag}/${getTagSlug(tag)}/`),
+							),
 						)}
 						aria-label={t("post.aria.tag", { tag: tag.title })}
 					>

--- a/packages/shared/src/components/organisms/PostCard.astro
+++ b/packages/shared/src/components/organisms/PostCard.astro
@@ -5,6 +5,7 @@ import type Article from "@/core/article/article.model";
 import { getTagSlug } from "@/core/tag";
 import { type Lang, useTranslatedPath, useTranslations } from "@/i18n";
 import { cleanEntityId } from "@/lib/collection.entity";
+import { ensureSingleTrailingSlash } from "@/lib/blog-post.utils";
 import { buildBlogUrl, getBlogBaseUrl } from "@/utils/blog-url";
 
 const currentLocale = Astro.currentLocale as Lang;
@@ -33,8 +34,8 @@ const siteOrigin = Astro.site?.origin;
 const blogBaseUrl = siteOrigin ? getBlogBaseUrl(siteOrigin) : "";
 const buildBlogHref = (path: string) =>
 	blogBaseUrl ? buildBlogUrl(path, siteOrigin) : path;
-const contentLink = buildBlogHref(
-	translatePath(`/${cleanEntityId(id).toLowerCase()}/`),
+const contentLink = ensureSingleTrailingSlash(
+	buildBlogHref(translatePath(`/${cleanEntityId(id).toLowerCase()}/`)),
 );
 ---
 

--- a/packages/shared/src/core/external-article/__tests__/blog-post.utils.test.ts
+++ b/packages/shared/src/core/external-article/__tests__/blog-post.utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import type Article from "@/core/article/article.model";
 import {
+	ensureSingleTrailingSlash,
 	getBlogPostRel,
 	getBlogPostTarget,
 	getBlogPostUrl,
@@ -108,6 +109,21 @@ describe("Blog Post Utils", () => {
 		test("should return blog URL with domain for regular articles", () => {
 			const url = getBlogPostUrl(mockArticle, "es", "https://yunielacosta.com");
 			expect(url).toContain("/es/2023/04/06/test-article");
+		});
+
+		test("should keep a single trailing slash for internal article links", () => {
+			expect(
+				ensureSingleTrailingSlash("/es/2026/03/26/api-versioning/"),
+			).toBe("/es/2026/03/26/api-versioning/");
+			expect(
+				ensureSingleTrailingSlash("https://blog.yunielacosta.com/es/2026/03/26/api-versioning/"),
+			).toBe("https://blog.yunielacosta.com/es/2026/03/26/api-versioning/");
+		});
+
+		test("should append a trailing slash only when missing", () => {
+			expect(ensureSingleTrailingSlash("/es/2026/03/26/api-versioning")).toBe(
+				"/es/2026/03/26/api-versioning/",
+			);
 		});
 	});
 

--- a/packages/shared/src/core/external-article/__tests__/blog-post.utils.test.ts
+++ b/packages/shared/src/core/external-article/__tests__/blog-post.utils.test.ts
@@ -125,6 +125,19 @@ describe("Blog Post Utils", () => {
 				"/es/2026/03/26/api-versioning/",
 			);
 		});
+
+		test("should collapse duplicated trailing slashes to a single slash", () => {
+			expect(ensureSingleTrailingSlash("/2023/04/03/understanding-cors-in-web-development//")).toBe(
+				"/2023/04/03/understanding-cors-in-web-development/",
+			);
+			expect(
+				ensureSingleTrailingSlash(
+					"https://blog.yunielacosta.com/2023/04/03/understanding-cors-in-web-development//",
+				),
+			).toBe(
+				"https://blog.yunielacosta.com/2023/04/03/understanding-cors-in-web-development/",
+			);
+		});
 	});
 
 	describe("getBlogPostTarget", () => {

--- a/packages/shared/src/core/external-article/__tests__/blog-post.utils.test.ts
+++ b/packages/shared/src/core/external-article/__tests__/blog-post.utils.test.ts
@@ -110,13 +110,17 @@ describe("Blog Post Utils", () => {
 			const url = getBlogPostUrl(mockArticle, "es", "https://yunielacosta.com");
 			expect(url).toContain("/es/2023/04/06/test-article");
 		});
+	});
 
+	describe("ensureSingleTrailingSlash", () => {
 		test("should keep a single trailing slash for internal article links", () => {
+			expect(ensureSingleTrailingSlash("/es/2026/03/26/api-versioning/")).toBe(
+				"/es/2026/03/26/api-versioning/",
+			);
 			expect(
-				ensureSingleTrailingSlash("/es/2026/03/26/api-versioning/"),
-			).toBe("/es/2026/03/26/api-versioning/");
-			expect(
-				ensureSingleTrailingSlash("https://blog.yunielacosta.com/es/2026/03/26/api-versioning/"),
+				ensureSingleTrailingSlash(
+					"https://blog.yunielacosta.com/es/2026/03/26/api-versioning/",
+				),
 			).toBe("https://blog.yunielacosta.com/es/2026/03/26/api-versioning/");
 		});
 
@@ -127,9 +131,11 @@ describe("Blog Post Utils", () => {
 		});
 
 		test("should collapse duplicated trailing slashes to a single slash", () => {
-			expect(ensureSingleTrailingSlash("/2023/04/03/understanding-cors-in-web-development//")).toBe(
-				"/2023/04/03/understanding-cors-in-web-development/",
-			);
+			expect(
+				ensureSingleTrailingSlash(
+					"/2023/04/03/understanding-cors-in-web-development//",
+				),
+			).toBe("/2023/04/03/understanding-cors-in-web-development/");
 			expect(
 				ensureSingleTrailingSlash(
 					"https://blog.yunielacosta.com/2023/04/03/understanding-cors-in-web-development//",

--- a/packages/shared/src/data/articles/en/2023/02/02/15-ways-to-improve-the-speed-of-your-java-application.mdx
+++ b/packages/shared/src/data/articles/en/2023/02/02/15-ways-to-improve-the-speed-of-your-java-application.mdx
@@ -119,7 +119,7 @@ The stored procedure has an advantage in data transfer and network traffic, as i
 
 Certain classes act as data holders within the application, such as **DB connection** objects or session objects for the user after login. These objects are heavy and their creation should be avoided multiple times, as they use a lot of resources. To improve application performance, we should **reuse** these objects instead of creating them, as this will reduce memory usage.
 
-We should use the **[Singleton pattern](/singleton-pattern)** whenever possible to create a single instance of an object and reuse it when needed, or clone the object instead of creating a new one.
+We should use the **[Singleton pattern](/2023/02/02/singleton-pattern/)** whenever possible to create a single instance of an object and reuse it when needed, or clone the object instead of creating a new one.
 
 ## 9. Use “contains” with caution in your Java applications
 

--- a/packages/shared/src/data/articles/es/2023/02/02/15-ways-to-improve-the-speed-of-your-java-application.mdx
+++ b/packages/shared/src/data/articles/es/2023/02/02/15-ways-to-improve-the-speed-of-your-java-application.mdx
@@ -120,7 +120,7 @@ La procedimiento almacenado tiene una ventaja en la transferencia de datos y el 
 
 Ciertas clases actúan como contenedores de datos dentro de la aplicación, como objetos de **conexión DB** o objetos de sesión para el usuario después del inicio de sesión. Estos objetos son pesados y su creación debe evitarse varias veces, ya que usan muchos recursos. Para mejorar el rendimiento de la aplicación, deberíamos **reutilizar** estos objetos en lugar de crearlos, ya que esto reducirá el uso de memoria.
 
-Deberíamos usar el [patrón **Singleton**](/es/singleton-pattern) siempre que sea posible para crear una única instancia de un objeto y reutilizarla cuando sea necesario, o clonar el objeto en lugar de crear uno nuevo.
+Deberíamos usar el [patrón **Singleton**](/es/2023/02/02/singleton-pattern/) siempre que sea posible para crear una única instancia de un objeto y reutilizarla cuando sea necesario, o clonar el objeto en lugar de crear uno nuevo.
 
 ## 9. Usa "\***\*contains\*\***" con precaución en tus aplicaciones de Java
 

--- a/packages/shared/src/lib/blog-post.utils.ts
+++ b/packages/shared/src/lib/blog-post.utils.ts
@@ -40,6 +40,13 @@ export function getBlogPostUrl(
 }
 
 /**
+ * Ensure internal blog links end with exactly one trailing slash.
+ */
+export function ensureSingleTrailingSlash(url: string): string {
+	return url.endsWith("/") ? url : `${url}/`;
+}
+
+/**
  * Get the target attribute for a blog post link
  */
 export function getBlogPostTarget(post: BlogPost): "_blank" | undefined {

--- a/packages/shared/src/lib/blog-post.utils.ts
+++ b/packages/shared/src/lib/blog-post.utils.ts
@@ -43,7 +43,13 @@ export function getBlogPostUrl(
  * Ensure internal blog links end with exactly one trailing slash.
  */
 export function ensureSingleTrailingSlash(url: string): string {
-	return `${url.replace(/\/+$/g, "")}/`;
+	let normalizedUrl = url;
+
+	while (normalizedUrl.endsWith("/")) {
+		normalizedUrl = normalizedUrl.slice(0, -1);
+	}
+
+	return `${normalizedUrl}/`;
 }
 
 /**

--- a/packages/shared/src/lib/blog-post.utils.ts
+++ b/packages/shared/src/lib/blog-post.utils.ts
@@ -43,7 +43,7 @@ export function getBlogPostUrl(
  * Ensure internal blog links end with exactly one trailing slash.
  */
 export function ensureSingleTrailingSlash(url: string): string {
-	return url.endsWith("/") ? url : `${url}/`;
+	return `${url.replace(/\/+$/g, "")}/`;
 }
 
 /**

--- a/packages/shared/src/lib/content-links.test.ts
+++ b/packages/shared/src/lib/content-links.test.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const articlesDir = path.resolve(import.meta.dirname, "../data/articles");
-const brokenRootLevelArticleLinkPattern = /\]\(\/(?:es\/)?[a-z0-9-]+\/?\)/g;
+const brokenRootLevelArticleLinkPattern =
+	/\]\(\/(?:[a-z]+(?:-[a-z]+)?\/)?[a-z0-9-]+\/?\)/g;
 
 const getArticleFiles = (directory: string): string[] => {
 	return readdirSync(directory).flatMap((entry) => {

--- a/packages/shared/src/lib/content-links.test.ts
+++ b/packages/shared/src/lib/content-links.test.ts
@@ -1,0 +1,35 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const articlesDir = path.resolve(import.meta.dirname, "../data/articles");
+const brokenRootLevelArticleLinkPattern = /\]\(\/(?:es\/)?[a-z0-9-]+\/?\)/g;
+
+const getArticleFiles = (directory: string): string[] => {
+	return readdirSync(directory).flatMap((entry) => {
+		const entryPath = path.join(directory, entry);
+		const stats = statSync(entryPath);
+
+		if (stats.isDirectory()) {
+			return getArticleFiles(entryPath);
+		}
+
+		return entryPath.endsWith(".mdx") ? [entryPath] : [];
+	});
+};
+
+describe("article content internal links", () => {
+	it("does not contain root-level article links that skip the dated permalink", () => {
+		const brokenLinks = getArticleFiles(articlesDir).flatMap((filePath) => {
+			const content = readFileSync(filePath, "utf8");
+			const matches = content.match(brokenRootLevelArticleLinkPattern) ?? [];
+
+			return matches.map((match) => ({
+				filePath: path.relative(articlesDir, filePath),
+				match,
+			}));
+		});
+
+		expect(brokenLinks).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- fix double-slash blog URLs generated by recent post links and shared portfolio post cards
- repair broken singleton article links that were causing 404s in the blog content
- add regression coverage for trailing slash normalization and invalid root-level article links

## Validation
- `pnpm --filter=@portfolio/shared test:unit -- --run src/core/external-article/__tests__/blog-post.utils.test.ts`
- `pnpm --filter=@portfolio/shared test:unit -- --run src/lib/content-links.test.ts`
- `pnpm --filter=blog check`
- `pnpm --filter=portfolio check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent trailing-slash normalization for blog and tag links to avoid broken or duplicated URLs.
  * Updated article links to use the standardized dated permalink paths.

* **Tests**
  * Added tests for trailing-slash normalization and a content-link check to detect disallowed/internal link patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->