### PR TITLE
fix: Potential fix for code scanning alert no. 19: Bad HTML filtering regexp

### DIFF
--- a/apps/blog/scripts/update-csp-script-hashes.mjs
+++ b/apps/blog/scripts/update-csp-script-hashes.mjs
@@ -32,7 +32,7 @@ const hashInlineScript = (scriptContent) => {
 	return `'sha256-${hash}'`;
 };
 
-const scriptRegex = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+const scriptRegex = /<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi;
 const srcRegex = /\bsrc\s*=/i;
 
 const hashes = new Set();

--- a/apps/blog/scripts/update-csp-script-hashes.mjs
+++ b/apps/blog/scripts/update-csp-script-hashes.mjs
@@ -32,7 +32,8 @@ const hashInlineScript = (scriptContent) => {
 	return `'sha256-${hash}'`;
 };
 
-const scriptRegex = /<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi;
+const scriptRegex =
+	/<script\b([^>]*)>([\s\S]*?)<\/script(?=[\t\n\f\r />])[^>]*>/gi;
 const srcRegex = /\bsrc\s*=/i;
 
 const hashes = new Set();


### PR DESCRIPTION
Potential fix for [https://github.com/yacosta738/yacosta738.github.io/security/code-scanning/19](https://github.com/yacosta738/yacosta738.github.io/security/code-scanning/19)

In general, the fix is to make the regular expression for matching `<script>` tags tolerant of optional whitespace and attributes on the closing tag, mirroring how browsers parse HTML. We should keep the existing capturing groups (attributes and content) so that behavior—extracting inline scripts without `src`—remains unchanged, but expand the closing-tag pattern.

Concretely, in `apps/blog/scripts/update-csp-script-hashes.mjs`, line 35 defines:

```js
const scriptRegex = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
```

We should modify only this line so that the closing tag matches `</script>` followed by optional whitespace and any non-`>` characters before the final `>`. A robust pattern is:

```js
const scriptRegex = /<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi;
```

Changes:

- Add `\b` after `</script` to ensure we still match the tag name as a whole word.
- Allow optional attributes or garbage on the closing tag with `[^>]*` before the final `>`.
- Keep the same flags (`gi`) and capture groups, so the rest of the code (using `match[1]` for attributes and `match[2]` for content) continues to work identically.

No new imports, helper methods, or additional code are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline script tag detection to handle edge cases with whitespace and additional attributes, ensuring proper security policy hash generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->