### PR TITLE
fix(blog): disable csso restructure to preserve Tailwind v4 responsive breakpoints

### DIFF
--- a/apps/blog/astro.config.mjs
+++ b/apps/blog/astro.config.mjs
@@ -94,9 +94,11 @@ export default defineConfig({
 		(await import("astro-compress")).default({
 			// Re-enable CSS compression now that the scoping issue is fixed
 			CSS: {
-				// Use csso for better CSS minification
+				// Use csso for CSS minification
+				// IMPORTANT: restructure must be false - csso breaks Tailwind v4's
+				// @layer + @media nesting, stripping responsive breakpoint wrappers
 				csso: {
-					restructure: true,
+					restructure: false,
 					forceMediaMerge: false,
 					comments: false,
 				},


### PR DESCRIPTION
## Problem

The blog layout on production (https://blog.yunielacosta.com/) was completely broken:
- Header showed hamburger menu on desktop instead of full navigation
- Blog cards displayed in a single column instead of responsive grid
- All responsive Tailwind utilities (`md:flex`, `md:hidden`, `lg:px-12`, etc.) were non-functional

## Root Cause

`astro-compress` uses `csso` for CSS minification. With `restructure: true`, csso reorganizes CSS structure for smaller output. However, **csso does not understand Tailwind v4's `@layer` + `@media` nesting**:

```css
/* Tailwind v4 generates this: */
@layer utilities {
  @media (width >= 48rem) {
    .md\:flex { display: flex }
    .md\:hidden { display: none }
  }
}

/* csso restructure strips the @media wrapper, producing: */
@layer utilities {
  .md\:flex { display: flex }   /* ← always applies, no breakpoint! */
  .md\:hidden { display: none }
}
```

This caused ALL responsive breakpoint media queries to be removed from the production CSS while keeping the selectors — making them apply unconditionally or not at all.

### Evidence collected from production

| Check | Result |
|---|---|
| `md:flex` computed display at 1920px | `none` (should be `flex`) |
| `md:hidden` computed display at 1920px | `flex` (should be `none`) |
| `md\:` selectors in CSS | Present |
| `48rem` breakpoint in CSS | **Missing** |
| Responsive `@media` queries found | **0 out of 15** |

## Fix

Set `restructure: false` in the csso config. This disables CSS restructuring while still performing safe minification (whitespace removal, shorthand merging, comment stripping).

## How to validate

1. Build the blog and inspect the output CSS for `@media (width >= 48rem)` presence
2. Deploy and verify the header shows full navigation on desktop
3. Verify blog cards render in responsive grid layout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CSS compression configuration to enhance compatibility with Tailwind v4 nesting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->