### PR TITLE
fix(styles): make Tailwind source detection explicit in monorepo

### DIFF
--- a/apps/blog/astro.config.mjs
+++ b/apps/blog/astro.config.mjs
@@ -94,9 +94,11 @@ export default defineConfig({
 		(await import("astro-compress")).default({
 			// Re-enable CSS compression now that the scoping issue is fixed
 			CSS: {
-				// Use csso for better CSS minification
+				// Use csso for CSS minification
+				// IMPORTANT: restructure must be false - csso breaks Tailwind v4's
+				// @layer + @media nesting, stripping responsive breakpoint wrappers
 				csso: {
-					restructure: true,
+					restructure: false,
 					forceMediaMerge: false,
 					comments: false,
 				},

--- a/packages/shared/src/styles/global.css
+++ b/packages/shared/src/styles/global.css
@@ -1,4 +1,8 @@
-@import "tailwindcss";
+@import "tailwindcss" source(none);
+
+/* Monorepo safety: make Tailwind source detection deterministic across apps.
+   Auto-detection can miss workspace files depending on the active app/build context,
+   so we register the exact source roots that contain utility classes. */
 @source "../../../../apps/portfolio/src";
 @source "../../../../apps/blog/src";
 @source "../../../../packages/shared/src";


### PR DESCRIPTION
## Summary

- make Tailwind source detection explicit for the monorepo stylesheet
- ensure blog builds scan `apps/blog/src` and `packages/shared/src` consistently
- target the real cause of missing responsive utilities used by shared components

## Problem

The blog production site still rendered the mobile header on desktop after the previous fix was merged.

Verified in production and preview at 1920px:
- `hidden md:flex` computed to `display: none`
- `md:hidden` computed to `display: flex`

That proved the responsive utilities were still missing from the emitted blog CSS.

## Root cause

The blog imports the shared global stylesheet from `packages/shared/src/styles/global.css`, and the responsive classes that control the header live in shared components under `packages/shared/src`.

Tailwind v4 automatic source detection was not reliably generating those utilities for the blog build in this monorepo context.

## Fix

Use explicit Tailwind source registration in the shared stylesheet:
- `@import "tailwindcss" source(none);`
- `@source "../../../../apps/portfolio/src";`
- `@source "../../../../apps/blog/src";`
- `@source "../../../../packages/shared/src";`

This makes content scanning deterministic and ensures responsive utilities from shared components are included in app builds.

## Validation

After deploy, verify on `blog.yunielacosta.com` that:
- desktop header shows full nav instead of hamburger
- blog cards/layout respond correctly at desktop breakpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CSS optimization configuration to ensure compatibility with Tailwind v4 nesting behavior.
  * Improved content source handling for more explicit CSS utility detection across monorepo packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->