### PR TITLE
fix(ci): exclude Sonar support files from coverage gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
             -Dsonar.test.inclusions=**/*.test.ts,**/*.spec.ts,**/tests/**
             -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info,packages/*/coverage/lcov.info
             -Dsonar.exclusions=**/dist/**,**/coverage/**,**/node_modules/**,**/.astro/**,apps/blog/src/data/**,packages/shared/src/data/**
-            -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/__tests__/**,**/tests/**
+            -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/__tests__/**,**/tests/**,**/playwright.config.ts,**/scripts/run-notion-sync.mjs,**/scripts/validate-notion-content.mjs
             -Dsonar.cpd.exclusions=**/content.config.ts,**/vitest.config.ts,**/playwright.config.ts,**/astro.config.mjs,**/organize-articles.js
 
       - name: SonarCloud Scan (Push/Main)
@@ -402,7 +402,7 @@ jobs:
             -Dsonar.test.inclusions=**/*.test.ts,**/*.spec.ts,**/tests/**
             -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info,packages/*/coverage/lcov.info
             -Dsonar.exclusions=**/dist/**,**/coverage/**,**/node_modules/**,**/.astro/**,apps/blog/src/data/**,packages/shared/src/data/**
-            -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/__tests__/**,**/tests/**
+            -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/__tests__/**,**/tests/**,**/playwright.config.ts,**/scripts/run-notion-sync.mjs,**/scripts/validate-notion-content.mjs
             -Dsonar.cpd.exclusions=**/content.config.ts,**/vitest.config.ts,**/playwright.config.ts,**/astro.config.mjs,**/organize-articles.js
 
       - name: SonarCloud main scan warning

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -53,5 +53,5 @@ jobs:
             -Dsonar.tests=apps,packages
             -Dsonar.test.inclusions=**/*.test.ts,**/*.spec.ts,**/tests/**
             -Dsonar.javascript.lcov.reportPaths=apps/*/coverage/lcov.info,packages/*/coverage/lcov.info
-            -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/__tests__/**,**/tests/**
+            -Dsonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/__tests__/**,**/tests/**,**/playwright.config.ts,**/scripts/run-notion-sync.mjs,**/scripts/validate-notion-content.mjs
             -Dsonar.cpd.exclusions=**/content.config.ts,**/vitest.config.ts,**/playwright.config.ts,**/astro.config.mjs,**/organize-articles.js


### PR DESCRIPTION
## Summary
- exclude Playwright and Notion support scripts from Sonar coverage calculations
- align the dedicated Sonar workflow and CI workflow so PR and main scans use the same coverage exclusions
- reduce false quality gate failures caused by non-production support files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SonarCloud coverage exclusion configuration in CI workflows to refine code coverage reporting metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->